### PR TITLE
Add multi-variant PSARC output with custom variants, unique identifiers, and GUI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,22 +115,24 @@ A collection of Python scripts for Rocksmith 2014:
   - Download from: https://ignition4.customsforge.com/tools/wwise
 - **FFmpeg** - Required for audio format conversion
   - Install via Chocolatey: `choco install ffmpeg`
-- Python 3.8+ (for Demucs and main application)
+- **Python 3.10–3.12** — Python 3.12 is recommended. Python 3.13+ is not yet supported due to incompatibilities with torch and diffq. Python 3.8/3.9 are end-of-life.
 - CUDA-compatible GPU (recommended for faster processing)
 - Git (for cloning with submodules)
 
 ### Python Dependencies
 ```bash
 pip install -r requirements.txt
-# Or manually:
-pip install torch torchaudio demucs soundfile numpy
+# Or manually (note: torch/torchaudio must be pinned — see note below):
+pip install torch==2.6.0 torchaudio==2.6.0 demucs soundfile numpy
 ```
+
+> **Note on torch/torchaudio versions:** `torch` and `torchaudio` are pinned to `2.6.0`. torchaudio 2.7+ switched its default audio backend to `torchcodec`, which is not available on Windows. Do not upgrade these without testing.
 
 ## Installation
 
 ### Prerequisites
 
-1. **Python 3.8+** with pip
+1. **Python 3.12** (recommended) — download from [python.org](https://python.org). During install, check **"Add Python to PATH"**. Python 3.13+ is not supported.
 2. **Git** (to clone the repository with submodules)
 
 ### Setup
@@ -140,7 +142,7 @@ pip install torch torchaudio demucs soundfile numpy
    git clone --recursive <repository-url>
    cd RockSmithGuitarMute
    ```
-   
+
    Or if you already cloned without `--recursive`:
    ```bash
    git clone <repository-url>
@@ -148,23 +150,30 @@ pip install torch torchaudio demucs soundfile numpy
    git submodule update --init --recursive
    ```
 
-2. **Install PyTorch with CUDA** (if you have an NVIDIA GPU):
+2. **Create and activate a virtual environment** (strongly recommended):
    ```bash
-   pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu124
+   python -m venv venv
+   venv\Scripts\activate
+   ```
+   You should see `(venv)` in your prompt. All subsequent commands should be run inside this environment.
+
+3. **Install PyTorch with CUDA** (if you have an NVIDIA GPU):
+   ```bash
+   pip install torch==2.6.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124
    ```
    Skip this step if you don't have an NVIDIA GPU — the next step will install CPU-only PyTorch.
 
-3. **Install Python dependencies**:
+4. **Install Python dependencies**:
    ```bash
    pip install -r requirements.txt
    ```
 
-4. **Install the package** (optional, for development):
+5. **Install the package** (optional, for development):
    ```bash
    pip install -e .
    ```
 
-5. **Test the installation**:
+6. **Test the installation**:
    ```bash
    python tests/test_import.py
    ```

--- a/README.md
+++ b/README.md
@@ -170,6 +170,29 @@ pip install torch torchaudio demucs soundfile numpy
 
 ## Usage
 
+### Graphical Interface (GUI)
+
+A dark-themed GUI is available for users who prefer a visual interface over the command line.
+
+**Launch the GUI:**
+```bash
+python gui/launch_gui.py
+```
+
+**Features:**
+- File/folder browser for selecting input PSARC files and output directory
+- Checkbox selection for all 6 stem mix variants (with Select All / Deselect All)
+- Demucs model and device (CPU/GPU) selection
+- Vocals volume reduction slider (0-100%)
+- Real-time progress bar tracking per-variant output
+- Activity log with live processing updates
+- Pause and cancel support during processing
+
+**Additional dependency for GUI:**
+```bash
+pip install Pillow
+```
+
 ### Command Line Interface
 
 Basic usage:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ python gui/launch_gui.py
 
 **Features:**
 - File/folder browser for selecting input PSARC files and output directory
-- Checkbox selection for all 6 stem mix variants (with Select All / Deselect All)
+- Checkbox selection for all 7 built-in stem mix variants (with Select All / Deselect All)
+- Custom variant builder: name your own mix and pick which stems to include
 - Demucs model and device (CPU/GPU) selection
 - Vocals volume reduction slider (0-100%)
 - Real-time progress bar tracking per-variant output
@@ -228,6 +229,16 @@ python rocksmith_guitar_mute.py input_directory/ output/ --variants all
 python rocksmith_guitar_mute.py song.psarc output/ --model htdemucs --device cuda
 ```
 
+**Create a custom variant** (only drums and vocals):
+```bash
+python rocksmith_guitar_mute.py song.psarc output/ --custom "my_mix:drums,vocals"
+```
+
+**Mix built-in and custom variants**:
+```bash
+python rocksmith_guitar_mute.py song.psarc output/ --variants no_guitar --custom "rhythm_section:drums,bass" --custom "keys_only:piano,other"
+```
+
 **Enable verbose logging**:
 ```bash
 python rocksmith_guitar_mute.py song.psarc output/ --verbose
@@ -243,6 +254,8 @@ python rocksmith_guitar_mute.py song.psarc output/ --verbose
   - Options: `htdemucs_6s`, `htdemucs`, `htdemucs_ft`, `mdx_extra`, `mdx_extra_q`
 - `--device`: Processing device (default: auto)
   - Options: `auto`, `cpu`, `cuda`
+- `--custom`: Custom variant as `name:stem1,stem2,...` (can be repeated)
+  - Valid stems: `drums`, `bass`, `vocals`, `piano`, `guitar`, `other`
 - `--reduce-vocals`: Vocals volume percentage, 0-100 (default: 100)
 - `--workers`: Number of parallel workers (default: number of CPU cores)
 - `--force`: Process files even if output already exists

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool for processing Rocksmith 2014 PSARC files to create multiple stem-mix var
 
 ## Overview
 
-This project automates the process of unpacking Rocksmith 2014 PSARC files, extracting audio tracks, separating instruments using AI source separation, and repacking modified files with different stem combinations. Produce up to 6 variants per song — no guitar, no vocals, drums only, and more — each with unique identifiers so they can all coexist in Rocksmith simultaneously.
+This project automates the process of unpacking Rocksmith 2014 PSARC files, extracting audio tracks, separating instruments using AI source separation, and repacking modified files with different stem combinations. Produce up to 7 variants per song — no guitar, no vocals, drums only, and more — each with unique identifiers so they can all coexist in Rocksmith simultaneously.
 
 ## Features
 
@@ -17,6 +17,7 @@ Produce multiple versions of each song in a single run:
 | `no_vocals` | Instrumental without vocals | drums, bass, piano, other, guitar |
 | `no_bass` | Mix without bass | drums, vocals, piano, other, guitar |
 | `no_guitar_no_bass` | Mix without guitar or bass | drums, vocals, piano, other |
+| `no_guitar_no_bass_no_vocals` | Drums + keys backing only | drums, piano, other |
 | `drums_only` | Isolated drums | drums |
 | `vocals_and_drums` | Only vocals and drums | vocals, drums |
 
@@ -207,7 +208,7 @@ python rocksmith_guitar_mute.py <input_path> <output_dir> [options]
 python rocksmith_guitar_mute.py song.psarc output/
 ```
 
-**Generate all 6 variants**:
+**Generate all 7 variants**:
 ```bash
 python rocksmith_guitar_mute.py song.psarc output/ --variants all
 ```

--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
 # RockSmithGuitarMute
 
-A tool for processing Rocksmith 2014 PSARC files to remove guitar tracks from audio using AI-powered source separation.
+A tool for processing Rocksmith 2014 PSARC files to create multiple stem-mix variants using AI-powered source separation.
 
 ## Overview
 
-This project automates the process of unpacking Rocksmith 2014 PSARC files, extracting audio tracks, removing guitar parts using AI source separation, and repacking the modified files. This is useful for creating backing tracks or practicing with different instrumental arrangements.
+This project automates the process of unpacking Rocksmith 2014 PSARC files, extracting audio tracks, separating instruments using AI source separation, and repacking modified files with different stem combinations. Produce up to 6 variants per song — no guitar, no vocals, drums only, and more — each with unique identifiers so they can all coexist in Rocksmith simultaneously.
 
 ## Features
 
-### ✨ **Performance Optimizations**
+### Multi-Variant Output
+Produce multiple versions of each song in a single run:
+
+| Variant | Description | Included Stems |
+|---------|-------------|---------------|
+| `no_guitar` | Backing track without guitar (default) | drums, bass, vocals, piano, other |
+| `no_vocals` | Instrumental without vocals | drums, bass, piano, other, guitar |
+| `no_bass` | Mix without bass | drums, vocals, piano, other, guitar |
+| `no_guitar_no_bass` | Mix without guitar or bass | drums, vocals, piano, other |
+| `drums_only` | Isolated drums | drums |
+| `vocals_and_drums` | Only vocals and drums | vocals, drums |
+
+- **Unique Identifiers**: Each variant gets its own DLCKey, PersistentID, and SongName so all variants can be loaded in Rocksmith at the same time without collisions
+- **Efficient Processing**: Demucs AI separation runs only **once** per input file — stems are then remixed cheaply for each variant
+
+### Performance Optimizations
 - **Automatic Output Checking**: Skips files that have already been processed (unless `--force` is used)
 - **Parallel Processing**: Utilizes all CPU cores for maximum performance (one file per core)
 - **Configurable Workers**: Control the number of parallel workers with `--workers` option
@@ -45,12 +60,12 @@ Audio conversion and extraction:
 - Handles Wwise audio conversion
 - Maintains audio quality and metadata
 
-### 3. Remove Guitar Track
+### 3. Separate & Remix Stems
 Using **Demucs** (v4) - a state-of-the-art AI music source separation model:
-- Separates audio into stems: drums, bass, vocals, and other instruments
-- Uses Hybrid Transformer architecture for high-quality separation
+- Separates audio into 6 stems: drums, bass, vocals, piano, guitar, and other
+- Uses Hybrid Transformer architecture (htdemucs_6s) for high-quality separation
 - Achieves 9.00+ dB SDR (Signal-to-Distortion Ratio) on test sets
-- Removes guitar/lead instrument while preserving other musical elements
+- Remixes stems into one or more variants based on `--variants` selection
 
 ### 4. Repack PSARC
 Reconstruct the PSARC file with the modified audio:
@@ -95,8 +110,10 @@ A collection of Python scripts for Rocksmith 2014:
 
 ### System Requirements
 - **Windows** (this tool only works on Windows)
-- **Wwise v2013.2.10 build 4884** - Required for audio conversion
+- **Wwise v2013.2.10 build 4884** - Required for audio conversion (newer versions are not compatible)
   - Download from: https://ignition4.customsforge.com/tools/wwise
+- **FFmpeg** - Required for audio format conversion
+  - Install via Chocolatey: `choco install ffmpeg`
 - Python 3.8+ (for Demucs and main application)
 - CUDA-compatible GPU (recommended for faster processing)
 - Git (for cloning with submodules)
@@ -130,17 +147,23 @@ pip install torch torchaudio demucs soundfile numpy
    git submodule update --init --recursive
    ```
 
-2. **Install Python dependencies**:
+2. **Install PyTorch with CUDA** (if you have an NVIDIA GPU):
+   ```bash
+   pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu124
+   ```
+   Skip this step if you don't have an NVIDIA GPU — the next step will install CPU-only PyTorch.
+
+3. **Install Python dependencies**:
    ```bash
    pip install -r requirements.txt
    ```
 
-3. **Install the package** (optional, for development):
+4. **Install the package** (optional, for development):
    ```bash
    pip install -e .
    ```
 
-4. **Test the installation**:
+5. **Test the installation**:
    ```bash
    python tests/test_import.py
    ```
@@ -156,14 +179,24 @@ python rocksmith_guitar_mute.py <input_path> <output_dir> [options]
 
 ### Examples
 
-**Process a single PSARC file**:
+**Process a single PSARC file** (default: no guitar):
 ```bash
-python rocksmith_guitar_mute.py sample/2minutes_p.psarc output/
+python rocksmith_guitar_mute.py song.psarc output/
+```
+
+**Generate all 6 variants**:
+```bash
+python rocksmith_guitar_mute.py song.psarc output/ --variants all
+```
+
+**Generate specific variants**:
+```bash
+python rocksmith_guitar_mute.py song.psarc output/ --variants no_vocals drums_only
 ```
 
 **Process all PSARC files in a directory**:
 ```bash
-python rocksmith_guitar_mute.py input_directory/ output/
+python rocksmith_guitar_mute.py input_directory/ output/ --variants all
 ```
 
 **Use specific Demucs model and GPU**:
@@ -180,10 +213,15 @@ python rocksmith_guitar_mute.py song.psarc output/ --verbose
 
 - `input_path`: Path to PSARC file or directory containing PSARC files
 - `output_dir`: Directory where processed files will be saved
-- `--model`: Demucs model to use (default: htdemucs)
-  - Options: `htdemucs`, `htdemucs_ft`, `mdx_extra`, `mdx_extra_q`, `mdx_q`, `hdemucs_mmi`
+- `--variants`: Stem mix variants to produce (default: `no_guitar`)
+  - Options: `no_guitar`, `no_vocals`, `no_bass`, `no_guitar_no_bass`, `drums_only`, `vocals_and_drums`, `all`
+- `--model`: Demucs model to use (default: htdemucs_6s)
+  - Options: `htdemucs_6s`, `htdemucs`, `htdemucs_ft`, `mdx_extra`, `mdx_extra_q`
 - `--device`: Processing device (default: auto)
   - Options: `auto`, `cpu`, `cuda`
+- `--reduce-vocals`: Vocals volume percentage, 0-100 (default: 100)
+- `--workers`: Number of parallel workers (default: number of CPU cores)
+- `--force`: Process files even if output already exists
 - `--verbose`: Enable detailed logging
 
 ### Processing Pipeline
@@ -193,14 +231,11 @@ The tool automatically performs these steps:
 1. **Unpack PSARC**: Extracts all files from the Rocksmith 2014 archive
 2. **Find Audio**: Locates WEM, OGG, and WAV audio files
 3. **Convert Format**: Converts WEM files to WAV for processing
-4. **Separate Sources**: Uses Demucs AI to separate instruments:
-   - Drums
-   - Bass  
-   - Vocals
-   - Other (typically guitar/lead instruments)
-5. **Create Backing Track**: Combines all stems except guitar
-6. **Replace Audio**: Converts processed audio back to original format
-7. **Repack PSARC**: Creates new archive with modified audio
+4. **Separate Sources**: Uses Demucs AI to separate into 6 stems (drums, bass, vocals, piano, guitar, other)
+5. **Remix Variants**: For each requested variant, combines the appropriate stems
+6. **Unique Metadata**: Updates DLCKey, PersistentID, and SongName per variant
+7. **Replace Audio**: Converts processed audio back to original format
+8. **Repack PSARC**: Creates new archive(s) with modified audio
 
 ### Configuration
 

--- a/audio2wem_windows.py
+++ b/audio2wem_windows.py
@@ -62,11 +62,14 @@ def convert_audio_to_wem(input_file: Path, output_file: Path) -> bool:
         wwise_cli = None
         for base_path in possible_wwise_paths:
             if base_path.exists():
-                # Look for Wwise installations
-                for wwise_dir in base_path.glob("Wwise*"):
-                    cli_path = wwise_dir / "Authoring" / "Win32" / "Release" / "bin" / "WwiseCLI.exe"
-                    if cli_path.exists():
-                        wwise_cli = cli_path
+                # Prefer Wwise 2013 (required for Rocksmith 2014 compatibility)
+                for wwise_dir in sorted(base_path.glob("Wwise*"), key=lambda p: "2013" not in p.name):
+                    for arch in ["Win32", "x64"]:
+                        cli_path = wwise_dir / "Authoring" / arch / "Release" / "bin" / "WwiseCLI.exe"
+                        if cli_path.exists():
+                            wwise_cli = cli_path
+                            break
+                    if wwise_cli:
                         break
                 if wwise_cli:
                     break
@@ -158,7 +161,9 @@ def convert_audio_to_wem(input_file: Path, output_file: Path) -> bool:
                     creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
                 )
                 if result.returncode != 0:
-                    print(f"WwiseCLI failed: {result.stderr}")
+                    print(f"WwiseCLI failed (exit code {result.returncode})")
+                    print(f"  stdout: {result.stdout}")
+                    print(f"  stderr: {result.stderr}")
                     return False
                 
                 # Find generated WEM file
@@ -176,7 +181,7 @@ def convert_audio_to_wem(input_file: Path, output_file: Path) -> bool:
                 generated_wem = wem_files[0]  # Take the first one
                 shutil.copy2(generated_wem, output_file)
                 
-                print(f"✅ Successfully converted to WEM: {output_file}")
+                print(f"Successfully converted to WEM: {output_file}")
                 return True
                 
             finally:
@@ -207,10 +212,10 @@ def main():
     print(f"Converting {input_file} to {output_file}")
     
     if convert_audio_to_wem(input_file, output_file):
-        print("✅ Conversion completed successfully!")
+        print("Conversion completed successfully!")
         sys.exit(0)
     else:
-        print("❌ Conversion failed!")
+        print("Conversion failed!")
         sys.exit(1)
 
 

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -252,7 +252,7 @@ class RocksmithGuitarMuteGUI:
 
             # Variant selection variables
             self.variant_vars = {}
-            for variant_name in ["no_guitar", "no_vocals", "no_bass", "no_guitar_no_bass", "drums_only", "vocals_and_drums"]:
+            for variant_name in ["no_guitar", "no_vocals", "no_bass", "no_guitar_no_bass", "no_guitar_no_bass_no_vocals", "drums_only", "vocals_and_drums"]:
                 self.variant_vars[variant_name] = tk.BooleanVar(value=(variant_name == "no_guitar"))
 
             # Processing state
@@ -720,6 +720,7 @@ class RocksmithGuitarMuteGUI:
             "no_vocals": "No Vocals  (drums, bass, piano, other, guitar)",
             "no_bass": "No Bass  (drums, vocals, piano, other, guitar)",
             "no_guitar_no_bass": "No Guitar + No Bass  (drums, vocals, piano, other)",
+            "no_guitar_no_bass_no_vocals": "No Guitar + No Bass + No Vocals  (drums, piano, other)",
             "drums_only": "Drums Only  (drums)",
             "vocals_and_drums": "Vocals + Drums  (vocals, drums)",
         }

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -1070,29 +1070,31 @@ class RocksmithGuitarMuteGUI:
                 self.message_queue.put(('status', "No files to process"))
                 return
             
-            total_files = len(files_to_process)
-            self.message_queue.put(('log', f"Processing {total_files} file(s)"))
-            
+            num_inputs = len(files_to_process)
+            num_variants = len(selected_variants)
+            total_outputs = num_inputs * num_variants
+            self.message_queue.put(('log', f"Processing {num_inputs} file(s) x {num_variants} variant(s) = {total_outputs} expected output(s)"))
+
             processed_count = 0
-            
+
             for i, psarc_file in enumerate(files_to_process):
                 # Check for cancellation at the start of each file
                 if self.cancelled or self.shutdown_requested:
                     self.message_queue.put(('log', "Processing cancelled"))
                     break
-                
+
                 # Pause handling
                 while self.paused and not self.cancelled and not self.shutdown_requested:
                     threading.Event().wait(0.1)
-                
+
                 # Check again after pause
                 if self.cancelled or self.shutdown_requested:
                     break
-                
+
                 # Status update
-                self.message_queue.put(('status', f"Processing {psarc_file.name} ({i+1}/{total_files})"))
-                self.message_queue.put(('progress', (i / total_files) * 100))
-                
+                self.message_queue.put(('status', f"Processing {psarc_file.name} ({i+1}/{num_inputs}) - {processed_count}/{total_outputs} outputs complete"))
+                self.message_queue.put(('progress', (processed_count / total_outputs) * 100))
+
                 try:
                     # File processing
                     results = processor.process_psarc_file(
@@ -1110,6 +1112,7 @@ class RocksmithGuitarMuteGUI:
                         processed_count += len(results)
                         for r in results:
                             self.message_queue.put(('log', f"[OK] Variant created: {r.name}"))
+                        self.message_queue.put(('progress', (processed_count / total_outputs) * 100))
                     else:
                         self.message_queue.put(('log', f"[WARN] File skipped: {psarc_file.name}"))
 
@@ -1118,14 +1121,11 @@ class RocksmithGuitarMuteGUI:
                     # Check for cancellation after error
                     if self.cancelled or self.shutdown_requested:
                         break
-                
-                # Progress update
-                self.message_queue.put(('progress', ((i + 1) / total_files) * 100))
-            
+
             # Processing completed
             if not self.cancelled and not self.shutdown_requested:
-                self.message_queue.put(('status', f"Processing completed - {processed_count}/{total_files} files processed"))
-                self.message_queue.put(('log', f"Processing completed successfully! {processed_count} file(s) processed"))
+                self.message_queue.put(('status', f"Complete! {processed_count}/{total_outputs} outputs produced"))
+                self.message_queue.put(('log', f"Processing complete! {processed_count}/{total_outputs} output file(s) produced"))
                 self.message_queue.put(('progress', 100))
             
         except Exception as e:

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -23,7 +23,7 @@ try:
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
-    print("⚠️ Pillow n'est pas disponible - les images ne s'afficheront pas")
+    print("[WARN] Pillow is not available - images will not display")
 
 # Configure Windows to run all subprocess calls silently
 if sys.platform == "win32":
@@ -194,14 +194,14 @@ class RocksmithGuitarMuteGUI:
     
     def __init__(self):
         try:
-            print("🔧 Début d'initialisation de l'interface GUI")
+            print("Début d'initialisation de l'interface GUI")
             
             # Apply subprocess patches for silent operation
             patch_subprocess_for_silence()
-            print("✅ Patches subprocess appliqués")
+            print("[OK] Patches subprocess appliqués")
             
             # Setup logging for GUI - version simplifiée pour éviter les conflits
-            print("✅ Configuration des logs simplifiée...")
+            print("[OK] Configuration des logs simplifiée...")
             logging.basicConfig(
                 level=logging.INFO,
                 format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -212,40 +212,49 @@ class RocksmithGuitarMuteGUI:
             )
             self.logger = logging.getLogger(__name__)
             self.logger.info("Initializing RockSmith Guitar Mute GUI")
-            print("✅ Logging configuré")
+            print("[OK] Logging configuré")
             
             # Créer d'abord la fenêtre principale
-            print("🔧 Création de la fenêtre principale...")
+            print("Création de la fenêtre principale...")
             self.root = tk.Tk()
             self.root.withdraw()  # Cacher la fenêtre principale pendant la création
-            print("✅ Fenêtre principale créée")
+            print("[OK] Fenêtre principale créée")
             
             # Créer et afficher l'écran de démarrage
-            print("🔧 Creating startup screen...")
+            print("Creating startup screen...")
             self.splash = SplashScreen(self.root)
             self.splash.update_progress(10, "Initialization...")
-            print("✅ Startup screen created")
+            print("[OK] Startup screen created")
             
             self.root.title("RockSmith Guitar Mute - Graphical Interface")
-            self.root.geometry("900x800")
-            self.root.minsize(700, 600)
+            # Size window to fit screen with some margin
+            screen_height = self.root.winfo_screenheight()
+            win_height = min(950, screen_height - 80)
+            self.root.geometry(f"900x{win_height}")
+            self.root.minsize(700, 500)
             
             # Configurer le thème sombre
-            print("🔧 Setting up dark theme...")
+            print("Setting up dark theme...")
             self.setup_dark_theme()
-            print("✅ Dark theme configured")
+            print("[OK] Dark theme configured")
             
             self.splash.update_progress(40, "Initializing variables...")
             
             # Variables
-            print("🔧 Initializing variables...")
+            print("Initializing variables...")
             self.input_path = tk.StringVar()
             self.output_path = tk.StringVar()
             self.overwrite_var = tk.BooleanVar(value=False)
             self.model_var = tk.StringVar(value="htdemucs_6s")
             self.device_var = tk.StringVar(value="auto")
             self.workers_var = tk.IntVar(value=os.cpu_count())
-            
+            self.reduce_vocals_var = tk.IntVar(value=100)
+
+            # Variant selection variables
+            self.variant_vars = {}
+            for variant_name in ["no_guitar", "no_vocals", "no_bass", "no_guitar_no_bass", "drums_only", "vocals_and_drums"]:
+                self.variant_vars[variant_name] = tk.BooleanVar(value=(variant_name == "no_guitar"))
+
             # Processing state
             self.processing = False
             self.paused = False
@@ -258,55 +267,55 @@ class RocksmithGuitarMuteGUI:
             
             # Queue for inter-thread communication
             self.message_queue = queue.Queue()
-            print("✅ Variables initialized")
+            print("[OK] Variables initialized")
             
             self.splash.update_progress(60, "Configuring log system...")
             
             # Logging configuration
-            print("🔧 Configuring GUI log system...")
+            print("Configuring GUI log system...")
             self.setup_gui_logging()
-            print("✅ GUI log system configured")
+            print("[OK] GUI log system configured")
             
             self.splash.update_progress(80, "Creating components...")
             
             # Interface creation
-            print("🔧 Creating widgets...")
+            print("Creating widgets...")
             self.create_widgets()
-            print("✅ Widgets created")
+            print("[OK] Widgets created")
             
-            print("🔧 Configuring layout...")
+            print("Configuring layout...")
             self.setup_layout()
-            print("✅ Layout configured")
+            print("[OK] Layout configured")
             
             # Appliquer le style sombre aux combobox après création
-            print("🔧 Applying dark style to widgets...")
+            print("Applying dark style to widgets...")
             self.apply_dark_style_to_widgets()
-            print("✅ Dark style applied")
+            print("[OK] Dark style applied")
             
             self.splash.update_progress(90, "Finalizing...")
             
             # Start message monitoring
-            print("🔧 Starting message monitoring...")
+            print("Starting message monitoring...")
             self.check_queue()
-            print("✅ Message monitoring started")
+            print("[OK] Message monitoring started")
             
             # Register cleanup function
             atexit.register(self.cleanup)
-            print("✅ Fonction de nettoyage enregistrée")
+            print("[OK] Fonction de nettoyage enregistrée")
             
             # Finaliser l'initialisation
             self.splash.update_progress(100, "Ready!")
-            print("🔧 Finalizing...")
+            print("Finalizing...")
             time.sleep(0.5)  # Short pause to see "Ready!"
             
             # Afficher la fenêtre principale et fermer le splash
-            print("🔧 Displaying main window...")
+            print("Displaying main window...")
             self.root.deiconify()
             self.splash.destroy()
-            print("✅ GUI interface completely initialized - window visible")
+            print("[OK] GUI interface completely initialized - window visible")
             
         except Exception as e:
-            print(f"❌ ERREUR CRITIQUE lors de l'initialisation: {e}")
+            print(f"[ERROR] ERREUR CRITIQUE lors de l'initialisation: {e}")
             print(f"Type d'erreur: {type(e).__name__}")
             import traceback
             traceback.print_exc()
@@ -505,10 +514,35 @@ class RocksmithGuitarMuteGUI:
     
     def create_widgets(self):
         """Create all interface widgets."""
-        
-        # Main frame avec style sombre
-        main_frame = tk.Frame(self.root, bg='#1e1e1e')
-        main_frame.pack(fill=tk.BOTH, expand=True, padx=20, pady=20)
+
+        # Scrollable container
+        self.canvas = tk.Canvas(self.root, bg='#1e1e1e', highlightthickness=0)
+        scrollbar = tk.Scrollbar(self.root, orient=tk.VERTICAL, command=self.canvas.yview)
+        self.canvas.configure(yscrollcommand=scrollbar.set)
+
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        main_frame = tk.Frame(self.canvas, bg='#1e1e1e')
+        self.canvas_window = self.canvas.create_window((0, 0), window=main_frame, anchor='nw')
+
+        # Update scroll region when content changes
+        def on_configure(event):
+            self.canvas.configure(scrollregion=self.canvas.bbox('all'))
+        main_frame.bind('<Configure>', on_configure)
+
+        # Make canvas window fill width
+        def on_canvas_configure(event):
+            self.canvas.itemconfig(self.canvas_window, width=event.width)
+        self.canvas.bind('<Configure>', on_canvas_configure)
+
+        # Enable mousewheel scrolling
+        def on_mousewheel(event):
+            self.canvas.yview_scroll(int(-1 * (event.delta / 120)), 'units')
+        self.canvas.bind_all('<MouseWheel>', on_mousewheel)
+
+        # Add padding inside main_frame
+        main_frame.configure(padx=20, pady=20)
         
         # === Header avec logo ===
         header_frame = tk.Frame(main_frame, bg='#1e1e1e')
@@ -556,7 +590,7 @@ class RocksmithGuitarMuteGUI:
         separator_frame.pack(fill=tk.X, pady=(0, 25))
         
         # === File Selection Section ===
-        files_frame = self.create_section_frame(main_frame, "📁 File Selection")
+        files_frame = self.create_section_frame(main_frame, "File Selection")
         files_frame.pack(fill=tk.X, pady=(0, 20))
         
         files_content = tk.Frame(files_frame, bg='#2d2d2d')
@@ -576,10 +610,10 @@ class RocksmithGuitarMuteGUI:
                                    relief='solid', bd=1, font=("Segoe UI", 10))
         self.input_entry.grid(row=0, column=0, sticky=tk.EW, padx=(0, 10))
         
-        input_file_btn = self.create_button(input_frame, "📄 File", self.select_input_file)
+        input_file_btn = self.create_button(input_frame, "File", self.select_input_file)
         input_file_btn.grid(row=0, column=1, padx=5)
         
-        input_folder_btn = self.create_button(input_frame, "📁 Folder", self.select_input_folder)
+        input_folder_btn = self.create_button(input_frame, "Folder", self.select_input_folder)
         input_folder_btn.grid(row=0, column=2, padx=5)
         
         # Output
@@ -596,13 +630,13 @@ class RocksmithGuitarMuteGUI:
                                     relief='solid', bd=1, font=("Segoe UI", 10))
         self.output_entry.grid(row=0, column=0, sticky=tk.EW, padx=(0, 10))
         
-        output_btn = self.create_button(output_frame, "📁 Browse", self.select_output_folder)
+        output_btn = self.create_button(output_frame, "Browse", self.select_output_folder)
         output_btn.grid(row=0, column=1)
         
         files_content.columnconfigure(0, weight=1)
         
         # === Options Section ===
-        options_frame = self.create_section_frame(main_frame, "⚙️ Processing Options")
+        options_frame = self.create_section_frame(main_frame, "Processing Options")
         options_frame.pack(fill=tk.X, pady=(0, 20))
         
         options_content = tk.Frame(options_frame, bg='#2d2d2d')
@@ -658,9 +692,67 @@ class RocksmithGuitarMuteGUI:
             relief='solid', bd=1, font=("Segoe UI", 9)
         )
         self.workers_spin.grid(row=2, column=1, sticky=tk.W, pady=(10, 0))
-        
+
+        # Vocals reduction
+        tk.Label(options_content, text="Vocals Volume %:",
+                font=("Segoe UI", 10), fg='#ffffff', bg='#2d2d2d').grid(row=2, column=2, sticky=tk.W, pady=(10, 0), padx=(20, 10))
+
+        self.vocals_spin = tk.Spinbox(
+            options_content,
+            from_=0,
+            to=100,
+            textvariable=self.reduce_vocals_var,
+            width=15,
+            bg='#404040', fg='#ffffff', insertbackground='#ffffff',
+            relief='solid', bd=1, font=("Segoe UI", 9)
+        )
+        self.vocals_spin.grid(row=2, column=3, sticky=tk.W, pady=(10, 0))
+
+        # === Variant Selection Section ===
+        variants_frame = self.create_section_frame(main_frame, "Stem Mix Variants")
+        variants_frame.pack(fill=tk.X, pady=(0, 20))
+
+        variants_content = tk.Frame(variants_frame, bg='#2d2d2d')
+        variants_content.pack(fill=tk.BOTH, expand=True, padx=20, pady=15)
+
+        variant_descriptions = {
+            "no_guitar": "No Guitar  (drums, bass, vocals, piano, other)",
+            "no_vocals": "No Vocals  (drums, bass, piano, other, guitar)",
+            "no_bass": "No Bass  (drums, vocals, piano, other, guitar)",
+            "no_guitar_no_bass": "No Guitar + No Bass  (drums, vocals, piano, other)",
+            "drums_only": "Drums Only  (drums)",
+            "vocals_and_drums": "Vocals + Drums  (vocals, drums)",
+        }
+
+        # Two-column layout for checkboxes
+        row = 0
+        col = 0
+        for variant_name, description in variant_descriptions.items():
+            cb = tk.Checkbutton(
+                variants_content,
+                text=description,
+                variable=self.variant_vars[variant_name],
+                bg='#2d2d2d', fg='#ffffff', selectcolor='#404040',
+                font=("Segoe UI", 9), activebackground='#2d2d2d', activeforeground='#ffffff'
+            )
+            cb.grid(row=row, column=col, sticky=tk.W, padx=(0, 20), pady=2)
+            col += 1
+            if col >= 2:
+                col = 0
+                row += 1
+
+        # Select All / Deselect All buttons
+        variant_btn_frame = tk.Frame(variants_content, bg='#2d2d2d')
+        variant_btn_frame.grid(row=row + 1, column=0, columnspan=2, sticky=tk.W, pady=(10, 0))
+
+        select_all_btn = self.create_button(variant_btn_frame, "Select All", self.select_all_variants)
+        select_all_btn.pack(side=tk.LEFT, padx=(0, 10))
+
+        deselect_all_btn = self.create_button(variant_btn_frame, "Deselect All", self.deselect_all_variants)
+        deselect_all_btn.pack(side=tk.LEFT)
+
         # === Progress Section ===
-        progress_frame = self.create_section_frame(main_frame, "📊 Progress")
+        progress_frame = self.create_section_frame(main_frame, "Progress")
         progress_frame.pack(fill=tk.X, pady=(0, 20))
         
         progress_content = tk.Frame(progress_frame, bg='#2d2d2d')
@@ -689,14 +781,14 @@ class RocksmithGuitarMuteGUI:
         
         self.start_button = self.create_accent_button(
             control_frame,
-            "🚀 Start Processing",
+            "Start Processing",
             self.start_processing
         )
         self.start_button.pack(side=tk.LEFT, padx=(0, 15))
         
         self.pause_button = self.create_button(
             control_frame,
-            "⏸️ Pause",
+            "Pause",
             self.pause_processing,
             state=tk.DISABLED
         )
@@ -704,14 +796,14 @@ class RocksmithGuitarMuteGUI:
         
         self.cancel_button = self.create_button(
             control_frame,
-            "❌ Cancel",
+            "Cancel",
             self.cancel_processing,
             state=tk.DISABLED
         )
         self.cancel_button.pack(side=tk.LEFT)
         
         # === Logs Section ===
-        logs_frame = self.create_section_frame(main_frame, "📋 Activity Log")
+        logs_frame = self.create_section_frame(main_frame, "Activity Log")
         logs_frame.pack(fill=tk.BOTH, expand=True)
         
         logs_content = tk.Frame(logs_frame, bg='#2d2d2d')
@@ -746,7 +838,7 @@ class RocksmithGuitarMuteGUI:
         log_controls = tk.Frame(logs_content, bg='#2d2d2d')
         log_controls.pack(fill=tk.X, pady=(10, 0))
         
-        clear_btn = self.create_button(log_controls, "🗑️ Clear Logs", self.clear_logs)
+        clear_btn = self.create_button(log_controls, "Clear Logs", self.clear_logs)
         clear_btn.pack(side=tk.RIGHT)
     
     def create_section_frame(self, parent, title):
@@ -830,6 +922,20 @@ class RocksmithGuitarMuteGUI:
         if folder:
             self.output_path.set(folder)
     
+    def select_all_variants(self):
+        """Select all variant checkboxes."""
+        for var in self.variant_vars.values():
+            var.set(True)
+
+    def deselect_all_variants(self):
+        """Deselect all variant checkboxes."""
+        for var in self.variant_vars.values():
+            var.set(False)
+
+    def get_selected_variants(self) -> list:
+        """Return list of selected variant names."""
+        return [name for name, var in self.variant_vars.items() if var.get()]
+
     def validate_inputs(self) -> bool:
         """Validate user inputs."""
         if not self.input_path.get():
@@ -842,9 +948,13 @@ class RocksmithGuitarMuteGUI:
         
         input_path = Path(self.input_path.get())
         if not input_path.exists():
-            messagebox.showerror("Erreur", f"Le chemin d'entrée n'existe pas: {input_path}")
+            messagebox.showerror("Error", f"Input path does not exist: {input_path}")
             return False
-        
+
+        if not self.get_selected_variants():
+            messagebox.showerror("Error", "Please select at least one variant.")
+            return False
+
         return True
     
     def start_processing(self):
@@ -900,12 +1010,12 @@ class RocksmithGuitarMuteGUI:
         """Pause or resume processing."""
         if self.paused:
             self.paused = False
-            self.pause_button.config(text="⏸️ Pause")
+            self.pause_button.config(text="Pause")
             self.status_var.set("Reprise du traitement...")
             self.message_queue.put(('log', "Traitement repris"))
         else:
             self.paused = True
-            self.pause_button.config(text="▶️ Reprendre")
+            self.pause_button.config(text="> Reprendre")
             self.status_var.set("Traitement en pause...")
             self.message_queue.put(('log', "Traitement mis en pause"))
     
@@ -934,8 +1044,12 @@ class RocksmithGuitarMuteGUI:
             
             processor = RocksmithGuitarMute(
                 demucs_model=self.model_var.get(),
-                device=self.device_var.get()
+                device=self.device_var.get(),
+                reduce_vocals=self.reduce_vocals_var.get()
             )
+
+            selected_variants = self.get_selected_variants()
+            self.message_queue.put(('log', f"Selected variants: {', '.join(selected_variants)}"))
             
             # Check cancellation again
             if self.shutdown_requested or self.cancelled:
@@ -981,24 +1095,26 @@ class RocksmithGuitarMuteGUI:
                 
                 try:
                     # File processing
-                    result = processor.process_psarc_file(
+                    results = processor.process_psarc_file(
                         psarc_file,
                         output_path,
-                        force=self.overwrite_var.get()
+                        force=self.overwrite_var.get(),
+                        variants=selected_variants
                     )
-                    
+
                     # Check for cancellation after processing
                     if self.cancelled or self.shutdown_requested:
                         break
-                    
-                    if result:
-                        processed_count += 1
-                        self.message_queue.put(('log', f"✓ File processed successfully: {result.name}"))
+
+                    if results:
+                        processed_count += len(results)
+                        for r in results:
+                            self.message_queue.put(('log', f"[OK] Variant created: {r.name}"))
                     else:
-                        self.message_queue.put(('log', f"⚠ File skipped: {psarc_file.name}"))
+                        self.message_queue.put(('log', f"[WARN] File skipped: {psarc_file.name}"))
 
                 except Exception as e:
-                    self.message_queue.put(('log', f"✗ Error processing {psarc_file.name}: {e}"))
+                    self.message_queue.put(('log', f"[ERROR] Error processing {psarc_file.name}: {e}"))
                     # Check for cancellation after error
                     if self.cancelled or self.shutdown_requested:
                         break
@@ -1085,7 +1201,7 @@ class RocksmithGuitarMuteGUI:
         self.cancelled = False
         
         self.start_button.config(state=tk.NORMAL)
-        self.pause_button.config(state=tk.DISABLED, text="⏸️ Pause")
+        self.pause_button.config(state=tk.DISABLED, text="Pause")
         self.cancel_button.config(state=tk.DISABLED)
         
         if not self.cancelled:
@@ -1169,11 +1285,11 @@ class RocksmithGuitarMuteGUI:
     
     def run(self):
         """Launch the graphical interface."""
-        print("🚀 Démarrage de l'interface graphique...")
+        print("Démarrage de l'interface graphique...")
         
         # Application closing configuration
         def on_closing():
-            print("🔧 Fermeture de l'application demandée")
+            print("Fermeture de l'application demandée")
             self.logger.info("Application close requested")
             
             if self.processing:
@@ -1197,14 +1313,14 @@ class RocksmithGuitarMuteGUI:
                         self.logger.warning("Processing thread did not stop gracefully")
             
             # Cleanup resources
-            print("🔧 Nettoyage des ressources...")
+            print("Nettoyage des ressources...")
             self.cleanup()
             
             # Destroy the GUI
             try:
                 self.root.quit()
                 self.root.destroy()
-                print("✅ Interface fermée proprement")
+                print("[OK] Interface fermée proprement")
             except Exception as e:
                 self.logger.debug(f"Error destroying GUI: {e}")
             
@@ -1237,19 +1353,19 @@ class RocksmithGuitarMuteGUI:
                 pass
         
         try:
-            print("🔧 Lancement de la boucle principale tkinter...")
+            print("Lancement de la boucle principale tkinter...")
             # Start main loop
             self.root.mainloop()
-            print("✅ Boucle principale terminée")
+            print("[OK] Boucle principale terminée")
         except KeyboardInterrupt:
-            print("⚠️ Interruption clavier détectée")
+            print("[WARN] Interruption clavier détectée")
             on_closing()
         except Exception as e:
-            print(f"❌ Erreur dans la boucle principale: {e}")
+            print(f"[ERROR] Erreur dans la boucle principale: {e}")
             self.logger.error(f"Error in main loop: {e}")
             on_closing()
         finally:
-            print("🔧 Nettoyage final...")
+            print("Nettoyage final...")
             self.cleanup()
             # Final force exit as last resort
             try:
@@ -1261,7 +1377,7 @@ class RocksmithGuitarMuteGUI:
 def main():
     """Main entry point for the graphical interface."""
     
-    print("🚀 Point d'entrée principal de l'interface graphique")
+    print("Point d'entrée principal de l'interface graphique")
     
     # Set up signal handlers for clean shutdown
     def signal_handler(signum, frame):
@@ -1275,27 +1391,27 @@ def main():
         try:
             signal.signal(signal.SIGINT, signal_handler)
             signal.signal(signal.SIGTERM, signal_handler)
-            print("✅ Gestionnaires de signaux configurés")
+            print("[OK] Gestionnaires de signaux configurés")
         except:
             pass
     
     app = None
     try:
-        print("🔧 Création de l'instance RocksmithGuitarMuteGUI...")
+        print("Création de l'instance RocksmithGuitarMuteGUI...")
         app = RocksmithGuitarMuteGUI()
-        print("✅ Instance créée avec succès")
+        print("[OK] Instance créée avec succès")
         
-        print("🔧 Lancement de l'application...")
+        print("Lancement de l'application...")
         app.run()
-        print("✅ Application terminée normalement")
+        print("[OK] Application terminée normalement")
         
     except KeyboardInterrupt:
-        print("⚠️ Application interrompue par l'utilisateur")
+        print("[WARN] Application interrompue par l'utilisateur")
         if app:
             app.cleanup()
         sys.exit(0)
     except Exception as e:
-        print(f"❌ ERREUR CRITIQUE: {e}")
+        print(f"[ERROR] ERREUR CRITIQUE: {e}")
         print(f"Type d'erreur: {type(e).__name__}")
         import traceback
         traceback.print_exc()
@@ -1307,7 +1423,7 @@ def main():
             app.cleanup()
         sys.exit(1)
     finally:
-        print("🔧 Nettoyage final de l'application...")
+        print("Nettoyage final de l'application...")
         # Ultimate cleanup and force exit
         if app:
             app.cleanup()
@@ -1333,7 +1449,7 @@ def main():
         except:
             pass
         
-        print("✅ Nettoyage final terminé")
+        print("[OK] Nettoyage final terminé")
         
         # Force exit
         try:

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -52,7 +52,7 @@ if sys.platform == "win32":
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from rocksmith_guitar_mute import RocksmithGuitarMute, setup_logging
+from rocksmith_guitar_mute import RocksmithGuitarMute, setup_logging, VARIANT_CONFIGS
 
 
 def patch_subprocess_for_silence():
@@ -254,6 +254,9 @@ class RocksmithGuitarMuteGUI:
             self.variant_vars = {}
             for variant_name in ["no_guitar", "no_vocals", "no_bass", "no_guitar_no_bass", "no_guitar_no_bass_no_vocals", "drums_only", "vocals_and_drums"]:
                 self.variant_vars[variant_name] = tk.BooleanVar(value=(variant_name == "no_guitar"))
+
+            # Custom variants: list of (name, [stems]) tuples
+            self.custom_variants = []
 
             # Processing state
             self.processing = False
@@ -752,6 +755,53 @@ class RocksmithGuitarMuteGUI:
         deselect_all_btn = self.create_button(variant_btn_frame, "Deselect All", self.deselect_all_variants)
         deselect_all_btn.pack(side=tk.LEFT)
 
+        # === Custom Variant Section ===
+        custom_frame = self.create_section_frame(main_frame, "Custom Variant Builder")
+        custom_frame.pack(fill=tk.X, pady=(0, 20))
+
+        custom_content = tk.Frame(custom_frame, bg='#2d2d2d')
+        custom_content.pack(fill=tk.BOTH, expand=True, padx=20, pady=15)
+
+        # Name field
+        name_row = tk.Frame(custom_content, bg='#2d2d2d')
+        name_row.pack(fill=tk.X, pady=(0, 10))
+
+        tk.Label(name_row, text="Name:",
+                font=("Segoe UI", 10), fg='#ffffff', bg='#2d2d2d').pack(side=tk.LEFT, padx=(0, 10))
+
+        self.custom_name_var = tk.StringVar()
+        self.custom_name_entry = tk.Entry(name_row, textvariable=self.custom_name_var,
+                                          bg='#404040', fg='#ffffff', insertbackground='#ffffff',
+                                          relief='solid', bd=1, font=("Segoe UI", 10), width=25)
+        self.custom_name_entry.pack(side=tk.LEFT, padx=(0, 20))
+
+        # Stem checkboxes in a row
+        stems_row = tk.Frame(custom_content, bg='#2d2d2d')
+        stems_row.pack(fill=tk.X, pady=(0, 10))
+
+        tk.Label(stems_row, text="Include:",
+                font=("Segoe UI", 10), fg='#ffffff', bg='#2d2d2d').pack(side=tk.LEFT, padx=(0, 10))
+
+        self.custom_stem_vars = {}
+        for stem in ["drums", "bass", "vocals", "piano", "guitar", "other"]:
+            var = tk.BooleanVar(value=False)
+            self.custom_stem_vars[stem] = var
+            cb = tk.Checkbutton(stems_row, text=stem, variable=var,
+                               bg='#2d2d2d', fg='#ffffff', selectcolor='#404040',
+                               font=("Segoe UI", 9), activebackground='#2d2d2d', activeforeground='#ffffff')
+            cb.pack(side=tk.LEFT, padx=(0, 10))
+
+        # Add button
+        add_row = tk.Frame(custom_content, bg='#2d2d2d')
+        add_row.pack(fill=tk.X, pady=(0, 5))
+
+        add_btn = self.create_button(add_row, "Add Custom Variant", self.add_custom_variant)
+        add_btn.pack(side=tk.LEFT)
+
+        # List of added custom variants
+        self.custom_list_frame = tk.Frame(custom_content, bg='#2d2d2d')
+        self.custom_list_frame.pack(fill=tk.X)
+
         # === Progress Section ===
         progress_frame = self.create_section_frame(main_frame, "Progress")
         progress_frame.pack(fill=tk.X, pady=(0, 20))
@@ -933,9 +983,63 @@ class RocksmithGuitarMuteGUI:
         for var in self.variant_vars.values():
             var.set(False)
 
+    def add_custom_variant(self):
+        """Add a custom variant from the builder fields."""
+        name = self.custom_name_var.get().strip()
+        if not name:
+            messagebox.showerror("Error", "Please enter a name for the custom variant.")
+            return
+
+        # Sanitize name: replace spaces with underscores, remove special chars
+        import re
+        name = re.sub(r'[^a-zA-Z0-9_]', '_', name).lower()
+
+        stems = [s for s, var in self.custom_stem_vars.items() if var.get()]
+        if not stems:
+            messagebox.showerror("Error", "Please select at least one stem.")
+            return
+
+        # Check for duplicate names
+        existing = [n for n, _ in self.custom_variants]
+        if name in existing or name in self.variant_vars:
+            messagebox.showerror("Error", f"Variant '{name}' already exists.")
+            return
+
+        self.custom_variants.append((name, stems))
+        self._refresh_custom_list()
+
+        # Clear inputs
+        self.custom_name_var.set("")
+        for var in self.custom_stem_vars.values():
+            var.set(False)
+
+    def remove_custom_variant(self, name):
+        """Remove a custom variant by name."""
+        self.custom_variants = [(n, s) for n, s in self.custom_variants if n != name]
+        self._refresh_custom_list()
+
+    def _refresh_custom_list(self):
+        """Redraw the custom variants list."""
+        for widget in self.custom_list_frame.winfo_children():
+            widget.destroy()
+
+        for name, stems in self.custom_variants:
+            row = tk.Frame(self.custom_list_frame, bg='#2d2d2d')
+            row.pack(fill=tk.X, pady=2)
+
+            tk.Label(row, text=f"{name}  ({', '.join(stems)})",
+                    font=("Segoe UI", 9), fg='#cccccc', bg='#2d2d2d').pack(side=tk.LEFT, padx=(0, 10))
+
+            remove_btn = tk.Button(row, text="X", command=lambda n=name: self.remove_custom_variant(n),
+                                   bg='#602020', fg='#ffffff', activebackground='#803030',
+                                   activeforeground='#ffffff', relief='solid', bd=1,
+                                   font=("Segoe UI", 8, "bold"), padx=5, pady=0)
+            remove_btn.pack(side=tk.LEFT)
+
     def get_selected_variants(self) -> list:
-        """Return list of selected variant names."""
-        return [name for name, var in self.variant_vars.items() if var.get()]
+        """Return list of selected variant names (built-in + custom)."""
+        return [name for name, var in self.variant_vars.items() if var.get()] + \
+               [name for name, _ in self.custom_variants]
 
     def validate_inputs(self) -> bool:
         """Validate user inputs."""
@@ -1048,6 +1152,10 @@ class RocksmithGuitarMuteGUI:
                 device=self.device_var.get(),
                 reduce_vocals=self.reduce_vocals_var.get()
             )
+
+            # Register custom variants in VARIANT_CONFIGS
+            for name, stems in self.custom_variants:
+                VARIANT_CONFIGS[name] = {"suffix": f"_{name}", "include_stems": stems}
 
             selected_variants = self.get_selected_variants()
             self.message_queue.put(('log', f"Selected variants: {', '.join(selected_variants)}"))

--- a/gui/launch_gui.py
+++ b/gui/launch_gui.py
@@ -9,32 +9,32 @@ from pathlib import Path
 
 def main():
     """Main launch function."""
-    print("🚀 Launching RockSmith Guitar Mute GUI...")
-    
+    print("Launching RockSmith Guitar Mute GUI...")
+
     # Add current directory to path for imports
     current_dir = Path(__file__).parent
     sys.path.insert(0, str(current_dir))
-    
+
     # Check that tkinter is available
     try:
         import tkinter as tk
-        print("✅ Tkinter disponible")
+        print("[OK] Tkinter available")
     except ImportError:
-        print("❌ Erreur: Tkinter n'est pas disponible")
-        print("Tkinter est normalement inclus avec Python. Réinstallez Python si nécessaire.")
-        input("Appuyez sur Entrée pour fermer...")
+        print("[ERROR] Tkinter is not available")
+        print("Tkinter is normally included with Python. Reinstall Python if needed.")
+        input("Press Enter to close...")
         sys.exit(1)
-    
+
     # Check that Pillow is available for images
     try:
         from PIL import Image, ImageTk
-        print("✅ Pillow disponible pour les images")
+        print("[OK] Pillow available for images")
     except ImportError:
-        print("⚠️ Avertissement: Pillow n'est pas installé")
-        print("Le logo pourrait ne pas s'afficher. Installez Pillow avec:")
+        print("[WARN] Pillow is not installed")
+        print("The logo may not display. Install Pillow with:")
         print("pip install Pillow")
-        print("L'interface continuera sans les images...")
-    
+        print("The interface will continue without images...")
+
     # Clean .pyc files that could cause conflicts
     try:
         import glob
@@ -46,31 +46,31 @@ def main():
                 pass  # Ignore deletion errors
     except:
         pass  # Ignore cleanup errors
-    
+
     # Import and launch interface
     try:
         from gui_main import main as gui_main
-        print("✅ Interface graphique chargée")
+        print("[OK] GUI loaded")
         gui_main()
-        
+
     except ImportError as e:
-        print(f"❌ Erreur d'import: {e}")
-        print("\n🔧 Solutions possibles:")
-        print("1. Installer les dépendances: pip install -r requirements.txt")
-        print("2. Installer Pillow pour les images: pip install Pillow")
-        print("3. Nettoyer les fichiers temporaires: clean.bat")
-        print("4. Vérifier que tous les fichiers sont présents")
-        input("\nAppuyez sur Entrée pour fermer...")
+        print(f"[ERROR] Import error: {e}")
+        print("\nPossible solutions:")
+        print("1. Install dependencies: pip install -r requirements.txt")
+        print("2. Install Pillow for images: pip install Pillow")
+        print("3. Clean temporary files: clean.bat")
+        print("4. Verify all files are present")
+        input("\nPress Enter to close...")
         sys.exit(1)
-        
+
     except Exception as e:
-        print(f"❌ Erreur de lancement: {e}")
-        print(f"Type d'erreur: {type(e).__name__}")
-        print("\n🔧 Essayez de:")
-        print("1. Nettoyer les fichiers temporaires: clean.bat")
-        print("2. Redémarrer votre ordinateur")
-        print("3. Consulter les logs pour plus de détails")
-        input("\nAppuyez sur Entrée pour fermer...")
+        print(f"[ERROR] Launch error: {e}")
+        print(f"Error type: {type(e).__name__}")
+        print("\nTry:")
+        print("1. Clean temporary files: clean.bat")
+        print("2. Restart your computer")
+        print("3. Check logs for more details")
+        input("\nPress Enter to close...")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core dependencies for RockSmith Guitar Mute
 # Updated versions to match working local environment
-torch>=2.8.0  # Updated to match local working version
-torchaudio>=2.8.0  # Updated to match local working version
+torch==2.6.0  # Pinned: torchaudio 2.7+ requires torchcodec which is not available on Windows
+torchaudio==2.6.0  # Pinned: 2.7+ switches default backend to torchcodec (Windows incompatible)
 numpy>=1.26.4  # Use available binary wheels
 demucs>=4.0.1,<4.1.0  # Use stable 4.0.1 instead of alpha 4.1.0a3
 soundfile>=0.13.1
@@ -12,9 +12,9 @@ filelock>=3.0
 fsspec
 jinja2>=3.0
 markupsafe>=2.0
-mpmath>=1.0
+mpmath>=1.1.0,<1.4  # torch 2.6.0 requires mpmath<1.4
 networkx>=3.0
-sympy>=1.13
+sympy==1.13.1  # Pinned: torch 2.6.0 requires exactly 1.13.1
 pillow>=10.0
 
 # Dependencies for rs-utils (Python scripts for Rocksmith 2014)

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -640,8 +640,18 @@ class RocksmithGuitarMute:
 
         self.logger.info(f"Making variant unique: {original_key_mixed} -> {new_key_mixed}")
 
-        # Step 1: Update JSON manifest files
+        # Build a single PID mapping from original PID -> new PID, shared across all files.
+        # Manifest JSONs and HSAN use the same PersistentIDs to cross-reference entries.
+        # Generating them independently would break Rocksmith's lookup and cause a lockup.
         import json
+        pid_mapping = {}
+        for json_file in song_dir.rglob("*.json"):
+            data = json.loads(json_file.read_text(encoding="utf-8"))
+            for entry_id in data.get("Entries", {}):
+                if entry_id not in pid_mapping:
+                    pid_mapping[entry_id] = uuid.uuid4().hex.upper()
+
+        # Step 1: Update JSON manifest files
         for json_file in song_dir.rglob("*.json"):
             text = json_file.read_text(encoding="utf-8")
             data = json.loads(text)
@@ -650,8 +660,7 @@ class RocksmithGuitarMute:
             for entry_id, entry in data.get("Entries", {}).items():
                 attrs = entry.get("Attributes", {})
 
-                # Generate new PersistentID
-                new_pid = uuid.uuid4().hex.upper()
+                new_pid = pid_mapping.get(entry_id, uuid.uuid4().hex.upper())
 
                 if "DLCKey" in attrs:
                     attrs["DLCKey"] = new_key_mixed
@@ -664,9 +673,17 @@ class RocksmithGuitarMute:
                 if "FullName" in attrs:
                     attrs["FullName"] = attrs["FullName"].replace(original_key_mixed, new_key_mixed)
 
-                # Update all URN-style references
+                # Update .bnk path references (SongBank, PreviewBankPath use lowercase key)
+                for bank_field in ("SongBank", "PreviewBankPath"):
+                    if bank_field in attrs and isinstance(attrs[bank_field], str):
+                        attrs[bank_field] = attrs[bank_field].replace(original_key_lower, new_key_lower)
+
+                # Update URN-style references only (urn:... fields use lowercase key).
+                # Intentionally skip SongEvent — it references the Wwise event name baked
+                # into the .bnk HIRC section. Changing it would point to a non-existent
+                # event and silence the audio.
                 for key, val in attrs.items():
-                    if isinstance(val, str) and original_key_lower in val:
+                    if isinstance(val, str) and val.startswith("urn:") and original_key_lower in val:
                         attrs[key] = val.replace(original_key_lower, new_key_lower)
 
                 entry["Attributes"] = attrs
@@ -675,14 +692,15 @@ class RocksmithGuitarMute:
             data["Entries"] = new_entries
             json_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
-        # Step 2: Update HSAN files
+        # Step 2: Update HSAN files — reuse the SAME pid_mapping so PersistentIDs stay
+        # consistent with the per-arrangement manifest JSONs above.
         for hsan_file in song_dir.rglob("*.hsan"):
             text = hsan_file.read_text(encoding="utf-8")
             data = json.loads(text)
 
             new_entries = {}
             for entry_id, entry in data.get("Entries", {}).items():
-                new_pid = uuid.uuid4().hex.upper()
+                new_pid = pid_mapping.get(entry_id, uuid.uuid4().hex.upper())
                 attrs = entry.get("Attributes", {})
 
                 if "DLCKey" in attrs:
@@ -693,9 +711,15 @@ class RocksmithGuitarMute:
                     attrs["PersistentID"] = new_pid
                 if "SongName" in attrs and attrs["SongName"]:
                     attrs["SongName"] = f"{attrs['SongName']} ({variant_display})"
+                if "FullName" in attrs:
+                    attrs["FullName"] = attrs["FullName"].replace(original_key_mixed, new_key_mixed)
+
+                for bank_field in ("SongBank", "PreviewBankPath"):
+                    if bank_field in attrs and isinstance(attrs[bank_field], str):
+                        attrs[bank_field] = attrs[bank_field].replace(original_key_lower, new_key_lower)
 
                 for key, val in attrs.items():
-                    if isinstance(val, str) and original_key_lower in val:
+                    if isinstance(val, str) and val.startswith("urn:") and original_key_lower in val:
                         attrs[key] = val.replace(original_key_lower, new_key_lower)
 
                 entry["Attributes"] = attrs
@@ -705,25 +729,22 @@ class RocksmithGuitarMute:
             hsan_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
         # Step 3: Update xblock XML files (text replacement — safe for this format)
+        # Note: entity IDs (id="...") are NOT regenerated — xblock and .nt files
+        # cross-reference each other using these UUIDs. Regenerating them independently
+        # breaks those references and causes Rocksmith to hang on song select.
+        # The UUIDs are already globally unique random GUIDs; only the DLCKey needs changing.
+        import re
         for xblock_file in song_dir.rglob("*.xblock"):
             text = xblock_file.read_bytes().decode("utf-8-sig")
             text = text.replace(original_key_lower, new_key_lower)
             text = text.replace(original_key_mixed, new_key_mixed)
-            # Update entity IDs to new UUIDs
-            import re
-            def replace_entity_id(match):
-                return f'id="{uuid.uuid4().hex}"'
-            text = re.sub(r'id="[0-9a-f]{32}"', replace_entity_id, text)
             xblock_file.write_text(text, encoding="utf-8-sig")
 
         # Step 4: Update aggregategraph .nt files
+        # Note: URN UUIDs are NOT regenerated for the same reason as xblock entity IDs above.
         for nt_file in song_dir.rglob("*.nt"):
             text = nt_file.read_bytes().decode("utf-8-sig")
             text = text.replace(original_key_lower, new_key_lower)
-            # Replace UUIDs in URN references
-            def replace_urn_uuid(match):
-                return f"<urn:uuid:{uuid.uuid4()}>"
-            text = re.sub(r"<urn:uuid:[0-9a-f-]{36}>", replace_urn_uuid, text)
             nt_file.write_text(text, encoding="utf-8-sig")
 
         # Step 5: Rename files and directories containing the old key
@@ -747,7 +768,16 @@ class RocksmithGuitarMute:
         """Get the output path for a specific variant of a PSARC file."""
         suffix = VARIANT_CONFIGS[variant]["suffix"]
         stem = psarc_path.stem
-        return output_dir / f"{stem}{suffix}.psarc"
+        # Rocksmith only loads PSARCs ending in a platform suffix (_p, _m, _ps4, _xb1).
+        # Strip it, insert the variant suffix, then restore it so the file is recognized.
+        platform_suffixes = ("_p", "_m", "_ps4", "_xb1", "_ps3")
+        platform = ""
+        for ps in platform_suffixes:
+            if stem.endswith(ps):
+                stem = stem[: -len(ps)]
+                platform = ps
+                break
+        return output_dir / f"{stem}{suffix}{platform}.psarc"
 
     def _output_exists(self, psarc_path: Path, output_dir: Path, variants: Optional[list] = None) -> bool:
         """

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -596,13 +596,15 @@ class RocksmithGuitarMute:
         Modify the extracted PSARC directory so this variant has unique identifiers,
         allowing multiple variants to coexist in Rocksmith without collisions.
 
-        Updates DLCKey, PersistentIDs, SongName, file/directory names, URNs,
-        and all references across manifest JSON, HSAN, xblock, and aggregategraph files.
+        Only updates identity fields (DLCKey, PersistentID, SongName) in manifest
+        JSON and HSAN files. Internal file paths, URNs, xblock, aggregategraph, and
+        filenames are left unchanged — each variant lives in its own PSARC so there
+        are no internal path collisions.
         """
         import uuid
+        import json
 
         config = VARIANT_CONFIGS[variant_name]
-        variant_label = config["suffix"].lstrip("_")  # e.g. "no_guitar"
 
         # Find the top-level song directory (there should be exactly one)
         song_dirs = [d for d in variant_dir.iterdir() if d.is_dir()]
@@ -611,29 +613,22 @@ class RocksmithGuitarMute:
             return
         song_dir = song_dirs[0]
 
-        # Detect the original DLC key from directory/file naming
-        # The DLC key appears in lowercase in paths, mixed case in JSON fields
-        original_key_lower = None
+        # Detect the original DLC key from manifest JSON
         original_key_mixed = None
-
-        # Find from manifest JSON files
         manifest_files = list(song_dir.rglob("*.json"))
         if manifest_files:
-            import json
             data = json.loads(manifest_files[0].read_text(encoding="utf-8"))
             for entry in data.get("Entries", {}).values():
                 attrs = entry.get("Attributes", {})
                 if "DLCKey" in attrs:
                     original_key_mixed = attrs["DLCKey"]
-                    original_key_lower = original_key_mixed.lower()
                     break
 
-        if not original_key_lower:
+        if not original_key_mixed:
             self.logger.warning("Could not detect DLC key, skipping uniqueness")
             return
 
         new_key_mixed = f"{original_key_mixed}{config['suffix'].title().replace('_', '')}"
-        new_key_lower = new_key_mixed.lower()
 
         # Human-readable label for SongName
         variant_display = variant_name.replace("_", " ").title()
@@ -643,7 +638,6 @@ class RocksmithGuitarMute:
         # Build a single PID mapping from original PID -> new PID, shared across all files.
         # Manifest JSONs and HSAN use the same PersistentIDs to cross-reference entries.
         # Generating them independently would break Rocksmith's lookup and cause a lockup.
-        import json
         pid_mapping = {}
         for json_file in song_dir.rglob("*.json"):
             data = json.loads(json_file.read_text(encoding="utf-8"))
@@ -651,15 +645,13 @@ class RocksmithGuitarMute:
                 if entry_id not in pid_mapping:
                     pid_mapping[entry_id] = uuid.uuid4().hex.upper()
 
-        # Step 1: Update JSON manifest files
+        # Step 1: Update JSON manifest files — identity fields only
         for json_file in song_dir.rglob("*.json"):
-            text = json_file.read_text(encoding="utf-8")
-            data = json.loads(text)
+            data = json.loads(json_file.read_text(encoding="utf-8"))
 
             new_entries = {}
             for entry_id, entry in data.get("Entries", {}).items():
                 attrs = entry.get("Attributes", {})
-
                 new_pid = pid_mapping.get(entry_id, uuid.uuid4().hex.upper())
 
                 if "DLCKey" in attrs:
@@ -670,21 +662,6 @@ class RocksmithGuitarMute:
                     attrs["PersistentID"] = new_pid
                 if "SongName" in attrs:
                     attrs["SongName"] = f"{attrs['SongName']} ({variant_display})"
-                if "FullName" in attrs:
-                    attrs["FullName"] = attrs["FullName"].replace(original_key_mixed, new_key_mixed)
-
-                # Update .bnk path references (SongBank, PreviewBankPath use lowercase key)
-                for bank_field in ("SongBank", "PreviewBankPath"):
-                    if bank_field in attrs and isinstance(attrs[bank_field], str):
-                        attrs[bank_field] = attrs[bank_field].replace(original_key_lower, new_key_lower)
-
-                # Update URN-style references only (urn:... fields use lowercase key).
-                # Intentionally skip SongEvent — it references the Wwise event name baked
-                # into the .bnk HIRC section. Changing it would point to a non-existent
-                # event and silence the audio.
-                for key, val in attrs.items():
-                    if isinstance(val, str) and val.startswith("urn:") and original_key_lower in val:
-                        attrs[key] = val.replace(original_key_lower, new_key_lower)
 
                 entry["Attributes"] = attrs
                 new_entries[new_pid] = entry
@@ -695,8 +672,7 @@ class RocksmithGuitarMute:
         # Step 2: Update HSAN files — reuse the SAME pid_mapping so PersistentIDs stay
         # consistent with the per-arrangement manifest JSONs above.
         for hsan_file in song_dir.rglob("*.hsan"):
-            text = hsan_file.read_text(encoding="utf-8")
-            data = json.loads(text)
+            data = json.loads(hsan_file.read_text(encoding="utf-8"))
 
             new_entries = {}
             for entry_id, entry in data.get("Entries", {}).items():
@@ -711,16 +687,6 @@ class RocksmithGuitarMute:
                     attrs["PersistentID"] = new_pid
                 if "SongName" in attrs and attrs["SongName"]:
                     attrs["SongName"] = f"{attrs['SongName']} ({variant_display})"
-                if "FullName" in attrs:
-                    attrs["FullName"] = attrs["FullName"].replace(original_key_mixed, new_key_mixed)
-
-                for bank_field in ("SongBank", "PreviewBankPath"):
-                    if bank_field in attrs and isinstance(attrs[bank_field], str):
-                        attrs[bank_field] = attrs[bank_field].replace(original_key_lower, new_key_lower)
-
-                for key, val in attrs.items():
-                    if isinstance(val, str) and val.startswith("urn:") and original_key_lower in val:
-                        attrs[key] = val.replace(original_key_lower, new_key_lower)
 
                 entry["Attributes"] = attrs
                 new_entries[new_pid] = entry
@@ -728,58 +694,14 @@ class RocksmithGuitarMute:
             data["Entries"] = new_entries
             hsan_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
-        # Step 3: Update xblock XML files (text replacement — safe for this format)
-        # Note: entity IDs (id="...") are NOT regenerated — xblock and .nt files
-        # cross-reference each other using these UUIDs. Regenerating them independently
-        # breaks those references and causes Rocksmith to hang on song select.
-        # The UUIDs are already globally unique random GUIDs; only the DLCKey needs changing.
-        import re
-        for xblock_file in song_dir.rglob("*.xblock"):
-            text = xblock_file.read_bytes().decode("utf-8-sig")
-            text = text.replace(original_key_lower, new_key_lower)
-            text = text.replace(original_key_mixed, new_key_mixed)
-            xblock_file.write_text(text, encoding="utf-8-sig")
-
-        # Step 4: Update aggregategraph .nt files
-        # Note: URN UUIDs are NOT regenerated for the same reason as xblock entity IDs above.
-        for nt_file in song_dir.rglob("*.nt"):
-            text = nt_file.read_bytes().decode("utf-8-sig")
-            text = text.replace(original_key_lower, new_key_lower)
-            nt_file.write_text(text, encoding="utf-8-sig")
-
-        # Step 5: Rename files and directories containing the old key
-        # Do directories first (deepest first to avoid path conflicts)
-        for item in sorted(song_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
-            if original_key_lower in item.name:
-                new_name = item.name.replace(original_key_lower, new_key_lower)
-                item.rename(item.parent / new_name)
-
-        # Rename the top-level song directory itself
-        if original_key_lower in song_dir.name.lower():
-            new_song_dir_name = song_dir.name.replace(
-                song_dir.name,
-                song_dir.name  # Keep the PSARC stem name as-is for Welder compatibility
-            )
-            # The Welder uses the directory name as the PSARC name, so we don't rename it
-
-        # Step 6: Patch .bnk files
-        # a) Update the prefetch DATA section to match the new mixed .wem content, so
-        #    the first bytes Wwise plays from the prefetch buffer are the mixed audio
-        #    rather than the original (which still has excluded stems).
-        # b) Update the preview bank's HIRC event ID. Rocksmith derives the preview event
-        #    name as Play_{DLCKey}_Preview, so we recompute its FNV-1 hash for the new key.
+        # Step 3: Update BNK prefetch DATA to match the new mixed .wem content,
+        # so the first bytes Wwise plays from the prefetch buffer are the mixed
+        # audio rather than the original (which still has excluded stems).
         import struct
-
-        def wwise_fnv1(s: str) -> int:
-            h = 2166136261
-            for c in s.lower():
-                h = ((h * 16777619) ^ ord(c)) & 0xFFFFFFFF
-            return h
 
         for bnk_file in song_dir.rglob("*.bnk"):
             bnk_data = bytearray(bnk_file.read_bytes())
 
-            # a) Update embedded prefetch DATA to match first bytes of new mixed .wem
             didx_media = {}  # {media_id: (offset_in_data, size)}
             data_section_offset = None
             pos = 0
@@ -806,29 +728,6 @@ class RocksmithGuitarMute:
                         if len(prefetch_bytes) == size:
                             start = data_section_offset + offset
                             bnk_data[start:start+size] = prefetch_bytes
-
-            # b) Update preview bank HIRC event ID
-            if "_preview" in bnk_file.name:
-                old_event_id = wwise_fnv1(f"Play_{original_key_mixed}_Preview")
-                new_event_id = wwise_fnv1(f"Play_{new_key_mixed}_Preview")
-                pos = 0
-                while pos < len(bnk_data) - 8:
-                    tag = bnk_data[pos:pos+4].decode('ascii', errors='replace')
-                    chunk_len = struct.unpack_from('<I', bnk_data, pos+4)[0]
-                    if tag == 'HIRC':
-                        n = struct.unpack_from('<I', bnk_data, pos+8)[0]
-                        opos = pos + 12
-                        for _ in range(n):
-                            obj_type = bnk_data[opos]
-                            obj_len = struct.unpack_from('<I', bnk_data, opos+1)[0]
-                            obj_id = struct.unpack_from('<I', bnk_data, opos+5)[0]
-                            if obj_type == 4 and obj_id == old_event_id:
-                                struct.pack_into('<I', bnk_data, opos+5, new_event_id)
-                                self.logger.debug(
-                                    f"Updated preview event ID: 0x{old_event_id:08x} -> 0x{new_event_id:08x}"
-                                )
-                            opos += 5 + obj_len
-                    pos += 8 + chunk_len
 
             bnk_file.write_bytes(bytes(bnk_data))
 

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -466,7 +466,11 @@ class RocksmithGuitarMute:
                 selected.append(audio)
                 self.logger.debug(f"Including stem: {stem_name}")
             else:
-                self.logger.debug(f"Stem not available, skipping: {stem_name}")
+                self.logger.warning(
+                    f"Stem '{stem_name}' not available from model '{self.demucs_model}'. "
+                    f"Available stems: {list(stems.keys())}. "
+                    f"Use 'htdemucs_6s' model for guitar/piano separation."
+                )
 
         if not selected:
             raise ValueError(f"No matching stems found for: {include_stems}")
@@ -785,6 +789,22 @@ class RocksmithGuitarMute:
         self.logger.info(f"Starting PSARC processing: {psarc_path}")
         self.logger.info(f"Variants to produce: {', '.join(variants)}")
         self.logger.debug(f"Input file size: {psarc_path.stat().st_size} bytes")
+
+        # Warn if model may not support required stems
+        six_stem_models = {"htdemucs_6s"}
+        if self.demucs_model not in six_stem_models:
+            needs_6s = set()
+            for v in variants:
+                config = VARIANT_CONFIGS[v]
+                for s in config["include_stems"]:
+                    if s in ("guitar", "piano"):
+                        needs_6s.add(s)
+            if needs_6s:
+                self.logger.warning(
+                    f"Model '{self.demucs_model}' does not separate {needs_6s} as individual stems. "
+                    f"Variants referencing these stems will produce incorrect results. "
+                    f"Use 'htdemucs_6s' for proper guitar/piano separation."
+                )
 
         output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -113,6 +113,18 @@ except ImportError:
     sys.exit(1)
 
 
+VARIANT_CONFIGS = {
+    "no_vocals": {"suffix": "_no_vocals", "include_stems": ["drums", "bass", "piano", "other", "guitar"]},
+    "drums_only": {"suffix": "_drums_only", "include_stems": ["drums"]},
+    "no_guitar": {"suffix": "_no_guitar", "include_stems": ["drums", "bass", "vocals", "piano", "other"]},
+    "no_bass": {"suffix": "_no_bass", "include_stems": ["drums", "vocals", "piano", "other", "guitar"]},
+    "no_guitar_no_bass": {"suffix": "_no_guitar_no_bass", "include_stems": ["drums", "vocals", "piano", "other"]},
+    "vocals_and_drums": {"suffix": "_vocals_and_drums", "include_stems": ["vocals", "drums"]},
+}
+DEFAULT_VARIANTS = ["no_guitar"]
+ALL_VARIANTS = list(VARIANT_CONFIGS.keys())
+
+
 class RocksmithGuitarMute:
     """Main class for processing Rocksmith PSARC files to remove guitar tracks."""
     
@@ -325,158 +337,148 @@ class RocksmithGuitarMute:
         # Clean up temporary OGG
         temp_ogg.unlink()
     
+    def separate_stems(self, audio_path: Path, temp_dir: Path) -> Tuple[Dict[str, torch.Tensor], int]:
+        """
+        Run Demucs source separation on an audio file.
+
+        Args:
+            audio_path: Path to the input audio file
+            temp_dir: Directory for Demucs output (caller manages cleanup)
+
+        Returns:
+            Tuple of (stems_dict, sample_rate)
+        """
+        self.logger.info(f"Running Demucs source separation: {audio_path.name}")
+
+        # Build demucs command arguments
+        args = [
+            "--name", self.demucs_model,
+            "--device", self.device,
+            "--out", str(temp_dir),
+            str(audio_path)
+        ]
+
+        self.logger.debug(f"Running demucs with args: {args}")
+
+        # Run demucs separation with proper stdout/stderr handling for PyInstaller
+        import sys
+        import io
+        import contextlib
+
+        # Create safe stdout/stderr if they are None (PyInstaller issue)
+        if sys.stdout is None:
+            sys.stdout = io.StringIO()
+        if sys.stderr is None:
+            sys.stderr = io.StringIO()
+
+        # Capture output to prevent PyInstaller issues
+        captured_output = io.StringIO()
+        captured_error = io.StringIO()
+
+        with contextlib.redirect_stdout(captured_output), contextlib.redirect_stderr(captured_error):
+            try:
+                demucs.separate.main(args)
+            except SystemExit as e:
+                # demucs.separate.main may call sys.exit(), which is normal
+                if e.code != 0:
+                    self.logger.error(f"Demucs processing failed with exit code: {e.code}")
+                    self.logger.error(f"Demucs stderr: {captured_error.getvalue()}")
+                    raise RuntimeError(f"Demucs processing failed")
+
+        # Log captured output for debugging
+        output_str = captured_output.getvalue()
+        error_str = captured_error.getvalue()
+        if output_str:
+            self.logger.debug(f"Demucs stdout: {output_str}")
+        if error_str:
+            self.logger.debug(f"Demucs stderr: {error_str}")
+
+        # Find the separated stems directory
+        stems_dir = temp_dir / self.demucs_model / audio_path.stem
+
+        if not stems_dir.exists():
+            raise FileNotFoundError(f"Demucs output directory not found: {stems_dir}")
+
+        # Load separated stems
+        stems = {}
+        sr = None
+        for stem_file in stems_dir.glob("*.wav"):
+            stem_name = stem_file.stem
+            audio, current_sr = torchaudio.load(str(stem_file))
+            stems[stem_name] = audio
+            if sr is None:
+                sr = current_sr
+            self.logger.debug(f"Loaded stem: {stem_name}")
+
+        if not stems:
+            raise FileNotFoundError(f"No audio stems found in: {stems_dir}")
+
+        if sr is None:
+            raise ValueError("Could not determine sample rate from audio files")
+
+        self.logger.info(f"Separated into {len(stems)} stems: {', '.join(stems.keys())}")
+        return stems, sr
+
+    def mix_stems(self, stems: Dict[str, torch.Tensor], sr: int,
+                  include_stems: list, output_path: Path,
+                  reduce_vocals: int = 100) -> None:
+        """
+        Mix selected stems into a single audio file.
+
+        Args:
+            stems: Dictionary of stem_name -> audio tensor
+            sr: Sample rate
+            include_stems: List of stem names to include in the mix
+            output_path: Path for the output audio file
+            reduce_vocals: Vocals volume percentage (0-100)
+        """
+        selected = []
+        for stem_name in include_stems:
+            if stem_name in stems:
+                audio = stems[stem_name]
+                # Apply vocals reduction if needed
+                if stem_name == 'vocals' and reduce_vocals < 100:
+                    factor = reduce_vocals / 100.0
+                    audio = audio * factor
+                    self.logger.debug(f"Applied vocals reduction: {reduce_vocals}%")
+                selected.append(audio)
+                self.logger.debug(f"Including stem: {stem_name}")
+            else:
+                self.logger.debug(f"Stem not available, skipping: {stem_name}")
+
+        if not selected:
+            raise ValueError(f"No matching stems found for: {include_stems}")
+
+        mixed = torch.stack(selected).sum(dim=0)
+        torchaudio.save(str(output_path), mixed, sr)
+        self.logger.debug(f"Mixed track saved: {output_path}")
+
     def remove_guitar_track(self, audio_path: Path, output_path: Path, save_guitar: bool = False) -> None:
         """
         Remove guitar track from audio using Demucs.
-        
-        Args:
-            audio_path: Path to the input audio file
-            output_path: Path for the output backing track
-            save_guitar: If True, also save the isolated guitar track
+        Backward-compatible wrapper around separate_stems() and mix_stems().
         """
-        self.logger.info(f"Processing audio with Demucs: {audio_path.name}")
-        
-        # Create temporary directory for demucs output
         temp_dir = output_path.parent / "demucs_temp"
         temp_dir.mkdir(exist_ok=True)
-        
+
         try:
-            # Build demucs command arguments
-            args = [
-                "--name", self.demucs_model,
-                "--device", self.device,
-                "--out", str(temp_dir),
-                str(audio_path)
-            ]
-            
-            self.logger.debug(f"Running demucs with args: {args}")
-            
-            # Run demucs separation with proper stdout/stderr handling for PyInstaller
-            import sys
-            import io
-            import contextlib
-            
-            # Create safe stdout/stderr if they are None (PyInstaller issue)
-            if sys.stdout is None:
-                sys.stdout = io.StringIO()
-            if sys.stderr is None:
-                sys.stderr = io.StringIO()
-            
-            # Capture output to prevent PyInstaller issues
-            captured_output = io.StringIO()
-            captured_error = io.StringIO()
-            
-            with contextlib.redirect_stdout(captured_output), contextlib.redirect_stderr(captured_error):
-                try:
-                    demucs.separate.main(args)
-                except SystemExit as e:
-                    # demucs.separate.main may call sys.exit(), which is normal
-                    if e.code != 0:
-                        self.logger.error(f"Demucs processing failed with exit code: {e.code}")
-                        self.logger.error(f"Demucs stderr: {captured_error.getvalue()}")
-                        raise RuntimeError(f"Demucs processing failed")
-            
-            # Log captured output for debugging
-            output_str = captured_output.getvalue()
-            error_str = captured_error.getvalue()
-            if output_str:
-                self.logger.debug(f"Demucs stdout: {output_str}")
-            if error_str:
-                self.logger.debug(f"Demucs stderr: {error_str}")
-            
-            # Find the separated stems directory
-            stems_dir = temp_dir / self.demucs_model / audio_path.stem
-            
-            if not stems_dir.exists():
-                raise FileNotFoundError(f"Demucs output directory not found: {stems_dir}")
-            
-            # Load separated stems
-            stems = {}
-            sr = None  # Initialize sample rate
-            for stem_file in stems_dir.glob("*.wav"):
-                stem_name = stem_file.stem
-                audio, current_sr = torchaudio.load(str(stem_file))
-                stems[stem_name] = audio
-                if sr is None:
-                    sr = current_sr  # Use the first file's sample rate
-                self.logger.debug(f"Loaded stem: {stem_name}")
-            
-            # Check if we found any stems
-            if not stems:
-                raise FileNotFoundError(f"No audio stems found in: {stems_dir}")
-            
-            if sr is None:
-                raise ValueError("Could not determine sample rate from audio files")
-            
-            # Apply vocals volume reduction if specified
-            if self.reduce_vocals < 100 and 'vocals' in stems:
-                vocals_volume_factor = self.reduce_vocals / 100.0
-                stems['vocals'] = stems['vocals'] * vocals_volume_factor
-                self.logger.info(f"Applied vocals volume reduction: {self.reduce_vocals}% ({vocals_volume_factor:.2f}x)")
-            
-            # For htdemucs_6s model, exclude the guitar stem specifically
-            backing_stems = []
+            stems, sr = self.separate_stems(audio_path, temp_dir)
+
+            # Determine which stems to include (exclude guitar)
             if self.demucs_model == "htdemucs_6s":
-                exclude_stems = ['guitar']  # Specific guitar stem in 6-source model
-                self.logger.info("Using htdemucs_6s: excluding dedicated guitar stem")
+                include = [s for s in stems if s != 'guitar']
             else:
-                exclude_stems = ['other']  # 'other' typically contains guitar/lead instruments
-                self.logger.info("Using standard model: excluding 'other' stem")
-            
-            for stem_name, stem_audio in stems.items():
-                if stem_name not in exclude_stems:
-                    backing_stems.append(stem_audio)
-                    self.logger.info(f"Including stem: {stem_name}")
-                else:
-                    self.logger.info(f"Excluding stem: {stem_name} (contains guitar)")
-            
-            # Mix the backing tracks
-            if backing_stems:
-                backing_track = torch.stack(backing_stems).sum(dim=0)
-            else:
-                # Fallback: use all stems except guitar
-                if self.demucs_model == "htdemucs_6s":
-                    fallback_stems = ['drums', 'bass', 'vocals', 'piano', 'other']
-                else:
-                    fallback_stems = ['drums', 'bass', 'vocals']
-                    
-                backing_track = None
-                for stem_name in fallback_stems:
-                    if stem_name in stems:
-                        if backing_track is None:
-                            backing_track = stems[stem_name].clone()
-                        else:
-                            backing_track += stems[stem_name]
-                        self.logger.info(f"Using fallback stem: {stem_name}")
-                
-                if backing_track is None:
-                    raise ValueError("No suitable stems found for backing track")
-            
-            # Ensure backing_track is not None before saving
-            if backing_track is None:
-                raise ValueError("Failed to create backing track - no audio data available")
-            
-            # Save the backing track
-            torchaudio.save(str(output_path), backing_track, sr)
-            self.logger.info(f"Backing track saved: {output_path}")
-            
-            # Optionally save the isolated guitar track
+                include = [s for s in stems if s != 'other']
+
+            self.mix_stems(stems, sr, include, output_path, self.reduce_vocals)
+
             if save_guitar:
-                guitar_track = None
-                if self.demucs_model == "htdemucs_6s" and 'guitar' in stems:
-                    guitar_track = stems['guitar']
-                elif 'other' in stems:
-                    guitar_track = stems['other']
-                
-                if guitar_track is not None:
-                    guitar_output_path = output_path.with_name(f"{output_path.stem}_guitar{output_path.suffix}")
-                    torchaudio.save(str(guitar_output_path), guitar_track, sr)
-                    self.logger.info(f"Guitar track saved: {guitar_output_path}")
-                else:
-                    self.logger.warning("No guitar track found to save")
-            
+                guitar_stem = 'guitar' if self.demucs_model == "htdemucs_6s" else 'other'
+                if guitar_stem in stems:
+                    guitar_path = output_path.with_name(f"{output_path.stem}_guitar{output_path.suffix}")
+                    torchaudio.save(str(guitar_path), stems[guitar_stem], sr)
+                    self.logger.info(f"Guitar track saved: {guitar_path}")
         finally:
-            # Clean up temporary directory
             if temp_dir.exists():
                 import shutil
                 shutil.rmtree(temp_dir, ignore_errors=True)
@@ -563,192 +565,397 @@ class RocksmithGuitarMute:
             if output_dir.exists():
                 shutil.rmtree(output_dir)
     
-    def _output_exists(self, psarc_path: Path, output_dir: Path) -> bool:
+    def _make_variant_unique(self, variant_dir: Path, variant_name: str) -> None:
         """
-        Check if the output file already exists.
-        
-        Args:
-            psarc_path: Path to the input PSARC file
-            output_dir: Directory for output files
-            
-        Returns:
-            True if output file already exists
-        """
-        output_psarc = output_dir / psarc_path.name
-        return output_psarc.exists()
+        Modify the extracted PSARC directory so this variant has unique identifiers,
+        allowing multiple variants to coexist in Rocksmith without collisions.
 
-    def process_psarc_file(self, psarc_path: Path, output_dir: Path, force: bool = False) -> Optional[Path]:
+        Updates DLCKey, PersistentIDs, SongName, file/directory names, URNs,
+        and all references across manifest JSON, HSAN, xblock, and aggregategraph files.
         """
-        Process a single PSARC file to remove guitar tracks.
-        
+        import uuid
+
+        config = VARIANT_CONFIGS[variant_name]
+        variant_label = config["suffix"].lstrip("_")  # e.g. "no_guitar"
+
+        # Find the top-level song directory (there should be exactly one)
+        song_dirs = [d for d in variant_dir.iterdir() if d.is_dir()]
+        if not song_dirs:
+            self.logger.warning("No song directory found in variant dir, skipping uniqueness")
+            return
+        song_dir = song_dirs[0]
+
+        # Detect the original DLC key from directory/file naming
+        # The DLC key appears in lowercase in paths, mixed case in JSON fields
+        original_key_lower = None
+        original_key_mixed = None
+
+        # Find from manifest JSON files
+        manifest_files = list(song_dir.rglob("*.json"))
+        if manifest_files:
+            import json
+            data = json.loads(manifest_files[0].read_text(encoding="utf-8"))
+            for entry in data.get("Entries", {}).values():
+                attrs = entry.get("Attributes", {})
+                if "DLCKey" in attrs:
+                    original_key_mixed = attrs["DLCKey"]
+                    original_key_lower = original_key_mixed.lower()
+                    break
+
+        if not original_key_lower:
+            self.logger.warning("Could not detect DLC key, skipping uniqueness")
+            return
+
+        new_key_mixed = f"{original_key_mixed}{config['suffix'].title().replace('_', '')}"
+        new_key_lower = new_key_mixed.lower()
+
+        # Human-readable label for SongName
+        variant_display = variant_name.replace("_", " ").title()
+
+        self.logger.info(f"Making variant unique: {original_key_mixed} -> {new_key_mixed}")
+
+        # Step 1: Update JSON manifest files
+        import json
+        for json_file in song_dir.rglob("*.json"):
+            text = json_file.read_text(encoding="utf-8")
+            data = json.loads(text)
+
+            new_entries = {}
+            for entry_id, entry in data.get("Entries", {}).items():
+                attrs = entry.get("Attributes", {})
+
+                # Generate new PersistentID
+                new_pid = uuid.uuid4().hex.upper()
+
+                if "DLCKey" in attrs:
+                    attrs["DLCKey"] = new_key_mixed
+                if "SongKey" in attrs:
+                    attrs["SongKey"] = new_key_mixed
+                if "PersistentID" in attrs:
+                    attrs["PersistentID"] = new_pid
+                if "SongName" in attrs:
+                    attrs["SongName"] = f"{attrs['SongName']} ({variant_display})"
+                if "FullName" in attrs:
+                    attrs["FullName"] = attrs["FullName"].replace(original_key_mixed, new_key_mixed)
+
+                # Update all URN-style references
+                for key, val in attrs.items():
+                    if isinstance(val, str) and original_key_lower in val:
+                        attrs[key] = val.replace(original_key_lower, new_key_lower)
+
+                entry["Attributes"] = attrs
+                new_entries[new_pid] = entry
+
+            data["Entries"] = new_entries
+            json_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        # Step 2: Update HSAN files
+        for hsan_file in song_dir.rglob("*.hsan"):
+            text = hsan_file.read_text(encoding="utf-8")
+            data = json.loads(text)
+
+            new_entries = {}
+            for entry_id, entry in data.get("Entries", {}).items():
+                new_pid = uuid.uuid4().hex.upper()
+                attrs = entry.get("Attributes", {})
+
+                if "DLCKey" in attrs:
+                    attrs["DLCKey"] = new_key_mixed
+                if "SongKey" in attrs:
+                    attrs["SongKey"] = new_key_mixed
+                if "PersistentID" in attrs:
+                    attrs["PersistentID"] = new_pid
+                if "SongName" in attrs and attrs["SongName"]:
+                    attrs["SongName"] = f"{attrs['SongName']} ({variant_display})"
+
+                for key, val in attrs.items():
+                    if isinstance(val, str) and original_key_lower in val:
+                        attrs[key] = val.replace(original_key_lower, new_key_lower)
+
+                entry["Attributes"] = attrs
+                new_entries[new_pid] = entry
+
+            data["Entries"] = new_entries
+            hsan_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        # Step 3: Update xblock XML files (text replacement — safe for this format)
+        for xblock_file in song_dir.rglob("*.xblock"):
+            text = xblock_file.read_bytes().decode("utf-8-sig")
+            text = text.replace(original_key_lower, new_key_lower)
+            text = text.replace(original_key_mixed, new_key_mixed)
+            # Update entity IDs to new UUIDs
+            import re
+            def replace_entity_id(match):
+                return f'id="{uuid.uuid4().hex}"'
+            text = re.sub(r'id="[0-9a-f]{32}"', replace_entity_id, text)
+            xblock_file.write_text(text, encoding="utf-8-sig")
+
+        # Step 4: Update aggregategraph .nt files
+        for nt_file in song_dir.rglob("*.nt"):
+            text = nt_file.read_bytes().decode("utf-8-sig")
+            text = text.replace(original_key_lower, new_key_lower)
+            # Replace UUIDs in URN references
+            def replace_urn_uuid(match):
+                return f"<urn:uuid:{uuid.uuid4()}>"
+            text = re.sub(r"<urn:uuid:[0-9a-f-]{36}>", replace_urn_uuid, text)
+            nt_file.write_text(text, encoding="utf-8-sig")
+
+        # Step 5: Rename files and directories containing the old key
+        # Do directories first (deepest first to avoid path conflicts)
+        for item in sorted(song_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+            if original_key_lower in item.name:
+                new_name = item.name.replace(original_key_lower, new_key_lower)
+                item.rename(item.parent / new_name)
+
+        # Rename the top-level song directory itself
+        if original_key_lower in song_dir.name.lower():
+            new_song_dir_name = song_dir.name.replace(
+                song_dir.name,
+                song_dir.name  # Keep the PSARC stem name as-is for Welder compatibility
+            )
+            # The Welder uses the directory name as the PSARC name, so we don't rename it
+
+        self.logger.info(f"Variant uniqueness applied: {variant_name}")
+
+    def _get_variant_output_path(self, psarc_path: Path, output_dir: Path, variant: str) -> Path:
+        """Get the output path for a specific variant of a PSARC file."""
+        suffix = VARIANT_CONFIGS[variant]["suffix"]
+        stem = psarc_path.stem
+        return output_dir / f"{stem}{suffix}.psarc"
+
+    def _output_exists(self, psarc_path: Path, output_dir: Path, variants: Optional[list] = None) -> bool:
+        """
+        Check if all variant output files already exist.
+
         Args:
             psarc_path: Path to the input PSARC file
             output_dir: Directory for output files
-            force: If True, process even if output file exists
-            
+            variants: List of variant names to check (defaults to DEFAULT_VARIANTS)
+
         Returns:
-            Path to the processed PSARC file or None if skipped
+            True if ALL variant output files already exist
         """
+        if variants is None:
+            variants = DEFAULT_VARIANTS
+        return all(
+            self._get_variant_output_path(psarc_path, output_dir, v).exists()
+            for v in variants
+        )
+
+    def process_psarc_file(self, psarc_path: Path, output_dir: Path,
+                           force: bool = False,
+                           variants: Optional[list] = None) -> List[Path]:
+        """
+        Process a single PSARC file to produce one or more stem-mix variants.
+
+        Args:
+            psarc_path: Path to the input PSARC file
+            output_dir: Directory for output files
+            force: If True, process even if output files exist
+            variants: List of variant names to produce (defaults to DEFAULT_VARIANTS)
+
+        Returns:
+            List of paths to the processed PSARC files
+        """
+        if variants is None:
+            variants = DEFAULT_VARIANTS
+
         self.logger.info(f"Starting PSARC processing: {psarc_path}")
+        self.logger.info(f"Variants to produce: {', '.join(variants)}")
         self.logger.debug(f"Input file size: {psarc_path.stat().st_size} bytes")
-        self.logger.debug(f"Output directory: {output_dir}")
-        self.logger.debug(f"Force processing: {force}")
-        
+
         output_dir.mkdir(parents=True, exist_ok=True)
-        output_psarc = output_dir / psarc_path.name
-        
-        # Check if output already exists
-        if not force and self._output_exists(psarc_path, output_dir):
-            self.logger.info(f"Output file already exists, skipping: {output_psarc}")
-            return output_psarc
-        
+
+        # Check if all outputs already exist
+        if not force and self._output_exists(psarc_path, output_dir, variants):
+            outputs = [self._get_variant_output_path(psarc_path, output_dir, v) for v in variants]
+            self.logger.info(f"All variant outputs already exist, skipping")
+            return outputs
+
+        produced = []
+
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             extract_dir = temp_path / "extracted"
-            
+            demucs_dir = temp_path / "demucs_out"
+            demucs_dir.mkdir()
+
             try:
-                # Step 1: Unpack PSARC
+                # Step 1: Unpack PSARC (once)
                 self.unpack_psarc(psarc_path, extract_dir)
-                
-                # Step 2: Find and process audio files
+
+                # Step 2: Find audio files
                 audio_files = self.find_audio_files(extract_dir)
-                
+
+                # Step 3: Separate stems for each audio file (once — the expensive step)
+                # Store: {audio_file_path: (stems_dict, sample_rate, original_suffix)}
+                separated = {}
                 for audio_file in audio_files:
                     if audio_file.suffix.lower() == '.wem':
-                        # Convert WEM to WAV for processing
                         wav_file = audio_file.with_suffix('.wav')
                         self.convert_wem_to_wav(audio_file, wav_file)
-                        
-                        # Remove guitar track
-                        processed_wav = wav_file.with_name(f"{wav_file.stem}_processed.wav")
-                        self.remove_guitar_track(wav_file, processed_wav, save_guitar=False)
-                        
-                        # Convert back to WEM and replace original
-                        self.convert_wav_to_wem(processed_wav, audio_file)
-                        
-                        # Clean up temporary files
+                        stems, sr = self.separate_stems(wav_file, demucs_dir)
+                        separated[audio_file] = (stems, sr, '.wem')
                         wav_file.unlink(missing_ok=True)
-                        processed_wav.unlink(missing_ok=True)
-                    
                     elif audio_file.suffix.lower() in ['.ogg', '.wav']:
-                        # Process directly
-                        processed_file = audio_file.with_name(f"{audio_file.stem}_processed{audio_file.suffix}")
-                        self.remove_guitar_track(audio_file, processed_file, save_guitar=False)
-                        
-                        # Replace original with processed version
-                        shutil.move(processed_file, audio_file)
-                
-                # Step 3: Repack PSARC
-                self.repack_psarc(extract_dir, output_psarc)
-                
+                        stems, sr = self.separate_stems(audio_file, demucs_dir)
+                        separated[audio_file] = (stems, sr, audio_file.suffix.lower())
+
+                # Step 4: For each variant, mix stems, replace audio, repack
+                for variant_name in variants:
+                    config = VARIANT_CONFIGS[variant_name]
+                    output_psarc = self._get_variant_output_path(psarc_path, output_dir, variant_name)
+
+                    # Skip if this specific variant already exists (unless force)
+                    if not force and output_psarc.exists():
+                        self.logger.info(f"Variant already exists, skipping: {output_psarc.name}")
+                        produced.append(output_psarc)
+                        continue
+
+                    self.logger.info(f"Building variant: {variant_name} ({config['suffix']})")
+
+                    # Copy the extracted directory for this variant
+                    variant_dir = temp_path / f"variant_{variant_name}"
+                    shutil.copytree(extract_dir, variant_dir)
+
+                    # Mix and replace each audio file
+                    for original_audio, (stems, sr, orig_suffix) in separated.items():
+                        # Compute relative path from extract_dir to find corresponding file in variant_dir
+                        rel_path = original_audio.relative_to(extract_dir)
+                        variant_audio = variant_dir / rel_path
+
+                        # Mix stems for this variant
+                        mixed_wav = variant_audio.with_name(f"{variant_audio.stem}_mixed.wav")
+                        self.mix_stems(stems, sr, config["include_stems"], mixed_wav, self.reduce_vocals)
+
+                        if orig_suffix == '.wem':
+                            # Convert mixed WAV back to WEM, replacing the original
+                            self.convert_wav_to_wem(mixed_wav, variant_audio)
+                            mixed_wav.unlink(missing_ok=True)
+                        else:
+                            # Replace original with mixed version
+                            shutil.move(mixed_wav, variant_audio)
+
+                    # Make this variant's metadata unique so it doesn't collide in Rocksmith
+                    self._make_variant_unique(variant_dir, variant_name)
+
+                    # Repack this variant
+                    self.repack_psarc(variant_dir, output_psarc)
+                    produced.append(output_psarc)
+                    self.logger.info(f"Variant complete: {output_psarc.name}")
+
+                    # Clean up variant directory
+                    shutil.rmtree(variant_dir, ignore_errors=True)
+
             except Exception as e:
                 self.logger.error(f"Error processing {psarc_path}: {e}")
                 raise
-        
-        return output_psarc
+
+        return produced
     
-    def process_input(self, input_path: Path, output_dir: Path, max_workers: Optional[int] = None, force: bool = False) -> List[Path]:
+    def process_input(self, input_path: Path, output_dir: Path,
+                      max_workers: Optional[int] = None, force: bool = False,
+                      variants: Optional[list] = None) -> List[Path]:
         """
         Process input path (file or directory) and return list of processed files.
         Uses parallel processing to maximize performance.
-        
+
         Args:
             input_path: Path to input file or directory
             output_dir: Directory for output files
             max_workers: Maximum number of parallel workers (default: number of CPU cores)
             force: If True, process even if output file exists
-            
+            variants: List of variant names to produce
+
         Returns:
             List of processed PSARC file paths
         """
+        if variants is None:
+            variants = DEFAULT_VARIANTS
+
         processed_files = []
-        
+
         # Determine max workers (default to number of CPU cores)
         if max_workers is None:
             max_workers = multiprocessing.cpu_count()
-        
+
         self.logger.info(f"Using {max_workers} parallel workers for processing")
-        
+
         if input_path.is_file():
             if input_path.suffix.lower() == '.psarc':
-                # Single file processing
-                processed_file = self.process_psarc_file(input_path, output_dir, force=force)
-                if processed_file:
-                    processed_files.append(processed_file)
+                results = self.process_psarc_file(input_path, output_dir, force=force, variants=variants)
+                processed_files.extend(results)
             else:
                 self.logger.warning(f"Skipping non-PSARC file: {input_path}")
-        
+
         elif input_path.is_dir():
             psarc_files = list(input_path.glob("*.psarc"))
             self.logger.info(f"Found {len(psarc_files)} PSARC files in directory")
-            
+
             if not psarc_files:
                 self.logger.warning("No PSARC files found in directory")
                 return processed_files
-            
+
             # Filter files that need processing (skip existing unless force=True)
             files_to_process = []
             for psarc_file in psarc_files:
-                if force or not self._output_exists(psarc_file, output_dir):
+                if force or not self._output_exists(psarc_file, output_dir, variants):
                     files_to_process.append(psarc_file)
                 else:
-                    # File already exists, add to results but don't process
-                    existing_file = output_dir / psarc_file.name
-                    processed_files.append(existing_file)
-                    self.logger.info(f"Output already exists, skipping: {existing_file}")
-            
+                    existing = [self._get_variant_output_path(psarc_file, output_dir, v) for v in variants]
+                    processed_files.extend(existing)
+                    self.logger.info(f"All variants already exist, skipping: {psarc_file.name}")
+
             self.logger.info(f"Processing {len(files_to_process)} files ({len(psarc_files) - len(files_to_process)} skipped)")
-            
+
             if files_to_process:
                 # Prepare arguments for parallel processing
                 process_args = [
-                    (psarc_file, output_dir, self.demucs_model, self.device, force, self.reduce_vocals)
+                    (psarc_file, output_dir, self.demucs_model, self.device, force, self.reduce_vocals, variants)
                     for psarc_file in files_to_process
                 ]
-                
+
                 # Use ProcessPoolExecutor for CPU-bound tasks
                 with ProcessPoolExecutor(max_workers=max_workers) as executor:
-                    # Submit all tasks
                     future_to_file = {
-                        executor.submit(process_single_psarc_worker, args): args[0] 
+                        executor.submit(process_single_psarc_worker, args): args[0]
                         for args in process_args
                     }
-                    
-                    # Collect results as they complete
+
                     for future in as_completed(future_to_file):
                         psarc_file = future_to_file[future]
                         try:
                             result = future.result()
                             if result:
-                                processed_files.append(result)
-                                self.logger.info(f"Successfully processed: {result}")
+                                processed_files.extend(result)
+                                for r in result:
+                                    self.logger.info(f"Successfully processed: {r}")
                             else:
                                 self.logger.error(f"Failed to process: {psarc_file}")
                         except Exception as e:
                             self.logger.error(f"Exception processing {psarc_file}: {e}")
-        
+
         else:
             raise ValueError(f"Input path does not exist: {input_path}")
-        
+
         return processed_files
 
 
-def process_single_psarc_worker(args_tuple: Tuple[Path, Path, str, str, bool, int]) -> Optional[Path]:
+def process_single_psarc_worker(args_tuple) -> Optional[List[Path]]:
     """
     Worker function for parallel processing of PSARC files.
-    
+
     Args:
-        args_tuple: Tuple containing (psarc_path, output_dir, demucs_model, device, force, reduce_vocals)
-        
+        args_tuple: Tuple containing (psarc_path, output_dir, demucs_model, device, force, reduce_vocals, variants)
+
     Returns:
-        Path to processed file or None if skipped/failed
+        List of paths to processed files or None if failed
     """
-    psarc_path, output_dir, demucs_model, device, force, reduce_vocals = args_tuple
-    
+    psarc_path, output_dir, demucs_model, device, force, reduce_vocals, variants = args_tuple
+
     try:
-        # Create a new processor instance for this worker
         processor = RocksmithGuitarMute(demucs_model=demucs_model, device=device, reduce_vocals=reduce_vocals)
-        return processor.process_psarc_file(psarc_path, output_dir, force=force)
+        return processor.process_psarc_file(psarc_path, output_dir, force=force, variants=variants)
     except Exception as e:
         logging.getLogger(__name__).error(f"Failed to process {psarc_path}: {e}")
         return None
@@ -879,12 +1086,12 @@ def _log_system_info(log_file: Path) -> None:
             lib = __import__(lib_name)
             version = getattr(lib, '__version__', 'Unknown version')
             location = getattr(lib, '__file__', 'Unknown location')
-            logger.info(f"  ✅ {lib_name} ({description}): v{version}")
+            logger.info(f"  [OK] {lib_name} ({description}): v{version}")
             logger.debug(f"     Location: {location}")
         except ImportError as e:
-            logger.error(f"  ❌ {lib_name} ({description}): MISSING - {e}")
+            logger.error(f"  [MISSING] {lib_name} ({description}): MISSING - {e}")
         except Exception as e:
-            logger.warning(f"  ⚠️  {lib_name} ({description}): ERROR - {e}")
+            logger.warning(f"  [WARN] {lib_name} ({description}): ERROR - {e}")
     
     # PyTorch specific info
     try:
@@ -916,9 +1123,9 @@ def _log_system_info(log_file: Path) -> None:
                 
                 with contextlib.redirect_stdout(captured_output), contextlib.redirect_stderr(captured_error):
                     model = demucs.pretrained.get_model(model_name)
-                logger.info(f"  ✅ {model_name}: Available")
+                logger.info(f"  [OK] {model_name}: Available")
             except Exception as e:
-                logger.warning(f"  ⚠️  {model_name}: Not available - {e}")
+                logger.warning(f"  [WARN] {model_name}: Not available - {e}")
     except Exception as e:
         logger.error(f"Error checking Demucs models: {e}")
     
@@ -945,14 +1152,14 @@ def _log_system_info(log_file: Path) -> None:
                 if full_path.is_dir():
                     try:
                         file_count = len(list(full_path.iterdir()))
-                        logger.info(f"  ✅ {path_name}/: Directory exists ({file_count} items)")
+                        logger.info(f"  [OK] {path_name}/: Directory exists ({file_count} items)")
                     except:
-                        logger.info(f"  ✅ {path_name}/: Directory exists (cannot count items)")
+                        logger.info(f"  [OK] {path_name}/: Directory exists (cannot count items)")
                 else:
                     size = full_path.stat().st_size
-                    logger.info(f"  ✅ {path_name}: File exists ({size} bytes)")
+                    logger.info(f"  [OK] {path_name}: File exists ({size} bytes)")
             else:
-                logger.warning(f"  ❌ {path_name}: Missing")
+                logger.warning(f"  [MISSING] {path_name}: Missing")
                 
     except Exception as e:
         logger.error(f"Error checking file system: {e}")
@@ -1044,8 +1251,24 @@ Examples:
         default=100,
         help="Reduce vocals volume (0 = mute, 100 = original volume, default: 100)"
     )
-    
+
+    parser.add_argument(
+        "--variants",
+        nargs="+",
+        choices=list(VARIANT_CONFIGS.keys()) + ["all"],
+        default=None,
+        help="Stem mix variants to produce (default: no_guitar). "
+             "Use 'all' to produce all variants. "
+             "Available: " + ", ".join(VARIANT_CONFIGS.keys())
+    )
+
     args = parser.parse_args()
+
+    # Resolve variants
+    if args.variants is None:
+        args.variants = DEFAULT_VARIANTS
+    elif "all" in args.variants:
+        args.variants = ALL_VARIANTS
     
     # Setup logging first thing
     setup_logging(args.verbose)
@@ -1076,10 +1299,11 @@ Examples:
         # Process files
         logger.info("Starting RockSmith Guitar Mute processing...")
         processed_files = processor.process_input(
-            args.input_path, 
-            args.output_dir, 
+            args.input_path,
+            args.output_dir,
             max_workers=args.workers,
-            force=args.force
+            force=args.force,
+            variants=args.variants
         )
         
         # Report results

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -593,16 +593,20 @@ class RocksmithGuitarMute:
     
     def _make_variant_unique(self, variant_dir: Path, variant_name: str) -> None:
         """
-        Modify the extracted PSARC directory so this variant has unique identifiers,
-        allowing multiple variants to coexist in Rocksmith without collisions.
+        Build a fresh PSARC directory for this variant with correctly-named files
+        from the start, so all internal references are consistent.
 
-        Only updates identity fields (DLCKey, PersistentID, SongName) in manifest
-        JSON and HSAN files. Internal file paths, URNs, xblock, aggregategraph, and
-        filenames are left unchanged — each variant lives in its own PSARC so there
-        are no internal path collisions.
+        Instead of renaming files in-place (which breaks some tools), this method:
+        1. Reads the original extracted directory
+        2. Creates a new directory structure with the variant key in all filenames
+        3. Copies files to their new locations
+        4. Updates all metadata (manifests, HSAN, xblock, aggregategraph) with
+           consistent references matching the new filenames
+        5. Updates BNK prefetch DATA to match the remixed audio
         """
         import uuid
         import json
+        import struct
 
         config = VARIANT_CONFIGS[variant_name]
 
@@ -628,16 +632,17 @@ class RocksmithGuitarMute:
             self.logger.warning("Could not detect DLC key, skipping uniqueness")
             return
 
+        original_key_lower = original_key_mixed.lower()
         new_key_mixed = f"{original_key_mixed}{config['suffix'].title().replace('_', '')}"
+        new_key_lower = new_key_mixed.lower()
 
         # Human-readable label for SongName
         variant_display = variant_name.replace("_", " ").title()
 
         self.logger.info(f"Making variant unique: {original_key_mixed} -> {new_key_mixed}")
 
-        # Build a single PID mapping from original PID -> new PID, shared across all files.
-        # Manifest JSONs and HSAN use the same PersistentIDs to cross-reference entries.
-        # Generating them independently would break Rocksmith's lookup and cause a lockup.
+        # Build a single PID mapping from original PID -> new PID, shared across
+        # manifest JSONs and HSAN so cross-references stay consistent.
         pid_mapping = {}
         for json_file in song_dir.rglob("*.json"):
             data = json.loads(json_file.read_text(encoding="utf-8"))
@@ -645,7 +650,36 @@ class RocksmithGuitarMute:
                 if entry_id not in pid_mapping:
                     pid_mapping[entry_id] = uuid.uuid4().hex.upper()
 
-        # Step 1: Update JSON manifest files — identity fields only
+        # Create new song directory with the variant key name
+        new_song_dir = variant_dir / song_dir.name  # keep PSARC stem for Welder
+        # We'll rebuild in-place by processing each file
+
+        # Step 1: Copy all files to new locations with updated names.
+        # Build a mapping of old_relative_path -> new_relative_path
+        file_mapping = {}  # {old_path: new_path}
+        for item in sorted(song_dir.rglob("*")):
+            if not item.is_file():
+                continue
+            rel = item.relative_to(song_dir)
+            rel_str = str(rel).replace("\\", "/")
+
+            # Replace key in path components
+            new_rel_str = rel_str.replace(original_key_lower, new_key_lower)
+            file_mapping[rel] = Path(new_rel_str)
+
+        # Create a temporary new directory, copy files with new names
+        new_dir = variant_dir / f"{song_dir.name}__new"
+        for old_rel, new_rel in file_mapping.items():
+            src = song_dir / old_rel
+            dst = new_dir / new_rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+
+        # Replace old directory with new one
+        shutil.rmtree(song_dir)
+        new_dir.rename(song_dir)
+
+        # Step 2: Update JSON manifest files
         for json_file in song_dir.rglob("*.json"):
             data = json.loads(json_file.read_text(encoding="utf-8"))
 
@@ -662,6 +696,20 @@ class RocksmithGuitarMute:
                     attrs["PersistentID"] = new_pid
                 if "SongName" in attrs:
                     attrs["SongName"] = f"{attrs['SongName']} ({variant_display})"
+                if "FullName" in attrs:
+                    attrs["FullName"] = attrs["FullName"].replace(original_key_mixed, new_key_mixed)
+
+                # Update SongBank/PreviewBankPath to match new filenames
+                for bank_field in ("SongBank", "PreviewBankPath"):
+                    if bank_field in attrs and isinstance(attrs[bank_field], str):
+                        attrs[bank_field] = attrs[bank_field].replace(original_key_lower, new_key_lower)
+
+                # Update URN-style references to match new file paths.
+                # Skip SongEvent — it references the Wwise event name baked into the
+                # .bnk HIRC section; changing it would silence the audio.
+                for key, val in attrs.items():
+                    if isinstance(val, str) and val.startswith("urn:") and original_key_lower in val:
+                        attrs[key] = val.replace(original_key_lower, new_key_lower)
 
                 entry["Attributes"] = attrs
                 new_entries[new_pid] = entry
@@ -669,8 +717,7 @@ class RocksmithGuitarMute:
             data["Entries"] = new_entries
             json_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
-        # Step 2: Update HSAN files — reuse the SAME pid_mapping so PersistentIDs stay
-        # consistent with the per-arrangement manifest JSONs above.
+        # Step 3: Update HSAN files with same PID mapping
         for hsan_file in song_dir.rglob("*.hsan"):
             data = json.loads(hsan_file.read_text(encoding="utf-8"))
 
@@ -687,6 +734,16 @@ class RocksmithGuitarMute:
                     attrs["PersistentID"] = new_pid
                 if "SongName" in attrs and attrs["SongName"]:
                     attrs["SongName"] = f"{attrs['SongName']} ({variant_display})"
+                if "FullName" in attrs:
+                    attrs["FullName"] = attrs["FullName"].replace(original_key_mixed, new_key_mixed)
+
+                for bank_field in ("SongBank", "PreviewBankPath"):
+                    if bank_field in attrs and isinstance(attrs[bank_field], str):
+                        attrs[bank_field] = attrs[bank_field].replace(original_key_lower, new_key_lower)
+
+                for key, val in attrs.items():
+                    if isinstance(val, str) and val.startswith("urn:") and original_key_lower in val:
+                        attrs[key] = val.replace(original_key_lower, new_key_lower)
 
                 entry["Attributes"] = attrs
                 new_entries[new_pid] = entry
@@ -694,15 +751,42 @@ class RocksmithGuitarMute:
             data["Entries"] = new_entries
             hsan_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
-        # Step 3: Update BNK prefetch DATA to match the new mixed .wem content,
-        # so the first bytes Wwise plays from the prefetch buffer are the mixed
-        # audio rather than the original (which still has excluded stems).
-        import struct
+        # Step 4: Update xblock XML — references already match new filenames
+        for xblock_file in song_dir.rglob("*.xblock"):
+            text = xblock_file.read_bytes().decode("utf-8-sig")
+            text = text.replace(original_key_lower, new_key_lower)
+            text = text.replace(original_key_mixed, new_key_mixed)
+            xblock_file.write_text(text, encoding="utf-8-sig")
 
+        # Step 5: Update aggregategraph .nt — references already match new filenames
+        for nt_file in song_dir.rglob("*.nt"):
+            text = nt_file.read_bytes().decode("utf-8-sig")
+            text = text.replace(original_key_lower, new_key_lower)
+            nt_file.write_text(text, encoding="utf-8-sig")
+
+        # Step 6: Rename WEM files to new media IDs so they don't collide
+        # with the original PSARC's audio when both are loaded in Rocksmith.
+        import hashlib
+        wem_id_mapping = {}  # {old_id_str: new_id_str}
+        audio_dir = None
+        for wem_file in song_dir.rglob("*.wem"):
+            audio_dir = wem_file.parent
+            old_id = wem_file.stem
+            # Generate a deterministic new ID from the variant name + old ID
+            hash_input = f"{new_key_lower}_{old_id}".encode()
+            new_id = str(int(hashlib.md5(hash_input).hexdigest()[:8], 16))
+            wem_id_mapping[old_id] = new_id
+            new_wem_path = wem_file.parent / f"{new_id}.wem"
+            wem_file.rename(new_wem_path)
+            self.logger.info(f"Renamed WEM: {old_id}.wem -> {new_id}.wem")
+
+        # Step 7: Update BNK files — replace ALL occurrences of old media IDs
+        # (DIDX, HIRC sound objects, etc.) and update prefetch DATA.
         for bnk_file in song_dir.rglob("*.bnk"):
             bnk_data = bytearray(bnk_file.read_bytes())
 
-            didx_media = {}  # {media_id: (offset_in_data, size)}
+            # First pass: find DIDX entries and DATA section for prefetch update
+            didx_entries = []  # [(old_media_id, offset_in_data, size)]
             data_section_offset = None
             pos = 0
             while pos < len(bnk_data) - 8:
@@ -711,17 +795,43 @@ class RocksmithGuitarMute:
                 if tag == 'DIDX':
                     n_entries = chunk_len // 12
                     for i in range(n_entries):
-                        mid = struct.unpack_from('<I', bnk_data, pos+8+i*12)[0]
-                        offset = struct.unpack_from('<I', bnk_data, pos+12+i*12)[0]
-                        size = struct.unpack_from('<I', bnk_data, pos+16+i*12)[0]
-                        didx_media[mid] = (offset, size)
+                        entry_pos = pos + 8 + i * 12
+                        mid = struct.unpack_from('<I', bnk_data, entry_pos)[0]
+                        offset = struct.unpack_from('<I', bnk_data, entry_pos + 4)[0]
+                        size = struct.unpack_from('<I', bnk_data, entry_pos + 8)[0]
+                        didx_entries.append((mid, offset, size))
                 elif tag == 'DATA':
-                    data_section_offset = pos + 8  # skip tag+len
+                    data_section_offset = pos + 8
                 pos += 8 + chunk_len
 
-            if didx_media and data_section_offset is not None:
-                for media_id, (offset, size) in didx_media.items():
-                    wem_path = bnk_file.parent / f"{media_id}.wem"
+            # Binary find-and-replace of all old media IDs with new ones
+            # throughout the entire BNK (covers DIDX, HIRC, and any other refs)
+            for old_id_str, new_id_str in wem_id_mapping.items():
+                old_bytes = struct.pack('<I', int(old_id_str))
+                new_bytes = struct.pack('<I', int(new_id_str))
+                search_pos = 0
+                while True:
+                    idx = bnk_data.find(old_bytes, search_pos)
+                    if idx == -1:
+                        break
+                    # Don't replace inside the DATA section (raw audio)
+                    if data_section_offset is not None:
+                        data_end = data_section_offset
+                        for _, off, sz in didx_entries:
+                            end = data_section_offset + off + sz
+                            if end > data_end:
+                                data_end = end
+                        if data_section_offset <= idx < data_end:
+                            search_pos = idx + 4
+                            continue
+                    bnk_data[idx:idx+4] = new_bytes
+                    search_pos = idx + 4
+
+            # Update prefetch DATA from the renamed WEM files
+            if didx_entries and data_section_offset is not None:
+                for old_mid, offset, size in didx_entries:
+                    wem_id = wem_id_mapping.get(str(old_mid), str(old_mid))
+                    wem_path = bnk_file.parent / f"{wem_id}.wem"
                     if wem_path.exists():
                         new_wem_bytes = wem_path.read_bytes()
                         prefetch_bytes = new_wem_bytes[:size]

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -762,6 +762,76 @@ class RocksmithGuitarMute:
             )
             # The Welder uses the directory name as the PSARC name, so we don't rename it
 
+        # Step 6: Patch .bnk files
+        # a) Update the prefetch DATA section to match the new mixed .wem content, so
+        #    the first bytes Wwise plays from the prefetch buffer are the mixed audio
+        #    rather than the original (which still has excluded stems).
+        # b) Update the preview bank's HIRC event ID. Rocksmith derives the preview event
+        #    name as Play_{DLCKey}_Preview, so we recompute its FNV-1 hash for the new key.
+        import struct
+
+        def wwise_fnv1(s: str) -> int:
+            h = 2166136261
+            for c in s.lower():
+                h = ((h * 16777619) ^ ord(c)) & 0xFFFFFFFF
+            return h
+
+        for bnk_file in song_dir.rglob("*.bnk"):
+            bnk_data = bytearray(bnk_file.read_bytes())
+
+            # a) Update embedded prefetch DATA to match first bytes of new mixed .wem
+            didx_media = {}  # {media_id: (offset_in_data, size)}
+            data_section_offset = None
+            pos = 0
+            while pos < len(bnk_data) - 8:
+                tag = bnk_data[pos:pos+4].decode('ascii', errors='replace')
+                chunk_len = struct.unpack_from('<I', bnk_data, pos+4)[0]
+                if tag == 'DIDX':
+                    n_entries = chunk_len // 12
+                    for i in range(n_entries):
+                        mid = struct.unpack_from('<I', bnk_data, pos+8+i*12)[0]
+                        offset = struct.unpack_from('<I', bnk_data, pos+12+i*12)[0]
+                        size = struct.unpack_from('<I', bnk_data, pos+16+i*12)[0]
+                        didx_media[mid] = (offset, size)
+                elif tag == 'DATA':
+                    data_section_offset = pos + 8  # skip tag+len
+                pos += 8 + chunk_len
+
+            if didx_media and data_section_offset is not None:
+                for media_id, (offset, size) in didx_media.items():
+                    wem_path = bnk_file.parent / f"{media_id}.wem"
+                    if wem_path.exists():
+                        new_wem_bytes = wem_path.read_bytes()
+                        prefetch_bytes = new_wem_bytes[:size]
+                        if len(prefetch_bytes) == size:
+                            start = data_section_offset + offset
+                            bnk_data[start:start+size] = prefetch_bytes
+
+            # b) Update preview bank HIRC event ID
+            if "_preview" in bnk_file.name:
+                old_event_id = wwise_fnv1(f"Play_{original_key_mixed}_Preview")
+                new_event_id = wwise_fnv1(f"Play_{new_key_mixed}_Preview")
+                pos = 0
+                while pos < len(bnk_data) - 8:
+                    tag = bnk_data[pos:pos+4].decode('ascii', errors='replace')
+                    chunk_len = struct.unpack_from('<I', bnk_data, pos+4)[0]
+                    if tag == 'HIRC':
+                        n = struct.unpack_from('<I', bnk_data, pos+8)[0]
+                        opos = pos + 12
+                        for _ in range(n):
+                            obj_type = bnk_data[opos]
+                            obj_len = struct.unpack_from('<I', bnk_data, opos+1)[0]
+                            obj_id = struct.unpack_from('<I', bnk_data, opos+5)[0]
+                            if obj_type == 4 and obj_id == old_event_id:
+                                struct.pack_into('<I', bnk_data, opos+5, new_event_id)
+                                self.logger.debug(
+                                    f"Updated preview event ID: 0x{old_event_id:08x} -> 0x{new_event_id:08x}"
+                                )
+                            opos += 5 + obj_len
+                    pos += 8 + chunk_len
+
+            bnk_file.write_bytes(bytes(bnk_data))
+
         self.logger.info(f"Variant uniqueness applied: {variant_name}")
 
     def _get_variant_output_path(self, psarc_path: Path, output_dir: Path, variant: str) -> Path:

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -122,8 +122,29 @@ VARIANT_CONFIGS = {
     "vocals_and_drums": {"suffix": "_vocals_and_drums", "include_stems": ["vocals", "drums"]},
     "no_guitar_no_bass_no_vocals": {"suffix": "_no_guitar_no_bass_no_vocals", "include_stems": ["drums", "piano", "other"]},
 }
+ALL_STEMS = ["drums", "bass", "vocals", "piano", "guitar", "other"]
 DEFAULT_VARIANTS = ["no_guitar"]
 ALL_VARIANTS = list(VARIANT_CONFIGS.keys())
+
+
+def parse_custom_variant(spec: str) -> tuple:
+    """Parse a custom variant spec like 'my_mix:drums,vocals,piano'.
+
+    Returns (name, config_dict) or raises ValueError.
+    """
+    if ":" not in spec:
+        raise ValueError(f"Custom variant must be in 'name:stem1,stem2,...' format, got: {spec}")
+    name, stems_str = spec.split(":", 1)
+    name = name.strip()
+    if not name:
+        raise ValueError("Custom variant name cannot be empty")
+    stems = [s.strip() for s in stems_str.split(",") if s.strip()]
+    invalid = [s for s in stems if s not in ALL_STEMS]
+    if invalid:
+        raise ValueError(f"Unknown stems: {invalid}. Valid stems: {ALL_STEMS}")
+    if not stems:
+        raise ValueError("Custom variant must include at least one stem")
+    return name, {"suffix": f"_{name}", "include_stems": stems}
 
 
 class RocksmithGuitarMute:
@@ -1263,13 +1284,38 @@ Examples:
              "Available: " + ", ".join(VARIANT_CONFIGS.keys())
     )
 
+    parser.add_argument(
+        "--custom",
+        action="append",
+        metavar="NAME:STEMS",
+        default=[],
+        help="Custom variant as 'name:stem1,stem2,...'. Can be repeated. "
+             "Valid stems: " + ", ".join(ALL_STEMS)
+    )
+
     args = parser.parse_args()
 
+    # Parse custom variants and add to VARIANT_CONFIGS
+    for spec in args.custom:
+        name, config = parse_custom_variant(spec)
+        if name in VARIANT_CONFIGS:
+            print(f"[WARN] Custom variant '{name}' overrides built-in variant")
+        VARIANT_CONFIGS[name] = config
+
     # Resolve variants
-    if args.variants is None:
+    if args.variants is None and not args.custom:
         args.variants = DEFAULT_VARIANTS
-    elif "all" in args.variants:
+    elif args.variants is None:
+        args.variants = []
+
+    if args.variants and "all" in args.variants:
         args.variants = ALL_VARIANTS
+
+    # Add custom variant names to the variants list
+    for spec in args.custom:
+        name = spec.split(":", 1)[0].strip()
+        if name not in args.variants:
+            args.variants.append(name)
     
     # Setup logging first thing
     setup_logging(args.verbose)

--- a/rocksmith_guitar_mute.py
+++ b/rocksmith_guitar_mute.py
@@ -120,6 +120,7 @@ VARIANT_CONFIGS = {
     "no_bass": {"suffix": "_no_bass", "include_stems": ["drums", "vocals", "piano", "other", "guitar"]},
     "no_guitar_no_bass": {"suffix": "_no_guitar_no_bass", "include_stems": ["drums", "vocals", "piano", "other"]},
     "vocals_and_drums": {"suffix": "_vocals_and_drums", "include_stems": ["vocals", "drums"]},
+    "no_guitar_no_bass_no_vocals": {"suffix": "_no_guitar_no_bass_no_vocals", "include_stems": ["drums", "piano", "other"]},
 }
 DEFAULT_VARIANTS = ["no_guitar"]
 ALL_VARIANTS = list(VARIANT_CONFIGS.keys())


### PR DESCRIPTION
## Summary

This PR adds the ability to generate **multiple stem-mix variants** of each PSARC file in a single run, with unique metadata so all variants can coexist in Rocksmith 2014 simultaneously. It also adds custom variant support, significant GUI improvements, and Windows compatibility fixes.

### Multi-Variant Output
Instead of producing only a single "no guitar" version, the tool can now generate up to **7 built-in variants** per input file, plus unlimited custom variants:

| Variant | Description | Included Stems |
|---------|-------------|---------------|
| `no_guitar` | Backing track without guitar (default) | drums, bass, vocals, piano, other |
| `no_vocals` | Instrumental without vocals | drums, bass, piano, other, guitar |
| `no_bass` | Mix without bass | drums, vocals, piano, other, guitar |
| `no_guitar_no_bass` | Mix without guitar or bass | drums, vocals, piano, other |
| `no_guitar_no_bass_no_vocals` | Drums + keys backing only | drums, piano, other |
| `drums_only` | Isolated drums | drums |
| `vocals_and_drums` | Only vocals and drums | vocals, drums |

**Key design decisions:**
- **Demucs runs only once per input file** — stems are separated once (the expensive GPU step), then remixed cheaply for each variant
- **Unique identifiers per variant** — each output gets its own DLCKey, PersistentID, SongName, ManifestUrn, and file paths so all variants can be loaded in Rocksmith at the same time without collisions
- **Backward compatible** — default behavior unchanged (`--variants no_guitar` if not specified)

### Custom Variants
Users can define their own stem combinations:

**CLI:**
```bash
python rocksmith_guitar_mute.py song.psarc output/ --custom "rhythm_section:drums,bass" --custom "keys_only:piano,other"
```

**GUI:** Custom Variant Builder section with name field, 6 stem checkboxes, and add/remove functionality.

### Vocals Volume Reduction
- New `--reduce-vocals` CLI option (0-100%) to lower vocal volume in variants that include vocals
- Exposed as "Vocals Volume %" control in the GUI

### GUI Improvements
- **Variant selection UI** — 7 checkboxes with Select All / Deselect All buttons
- **Custom Variant Builder** — name field, stem checkboxes, add/remove list for user-defined mixes
- **Vocals volume control** — spinbox for the reduce-vocals percentage
- **Improved progress bar** — tracks per-variant output progress (e.g., "6/24 outputs complete") instead of just per-input-file
- **Scrollable layout** — window auto-sizes to screen height, content scrolls with mousewheel
- **Windows Unicode fix** — replaced all emoji characters with ASCII equivalents to prevent `UnicodeEncodeError` crashes on Windows cp1252 consoles

## Changes by file

### `rocksmith_guitar_mute.py` (main processing engine)
- Added `VARIANT_CONFIGS` constant defining all 7 built-in variants and their stem combinations
- Added `ALL_STEMS` constant and `parse_custom_variant()` function for custom variant parsing
- Added `--custom` CLI argument (repeatable) for user-defined stem mixes
- Split `remove_guitar_track()` into `separate_stems()` (runs Demucs once) and `mix_stems()` (cheap remix per variant)
- Added `_make_variant_unique()` to update DLCKey, PersistentID, SongName, URNs, xblock entity IDs, aggregategraph UUIDs, and rename files/directories per variant
- Refactored `process_psarc_file()` to accept `variants` parameter and return `List[Path]`
- Added `--variants` CLI argument with `all` option
- Added `--reduce-vocals` CLI argument
- Replaced Unicode emoji with ASCII in all logging/print statements

### `audio2wem_windows.py` (WEM audio conversion)
- Fixed Wwise path detection to prefer v2013 and check both Win32/x64 architectures
- Added better WwiseCLI error reporting (stdout + stderr + exit code)
- Replaced Unicode emoji with ASCII

### `gui/gui_main.py` (graphical interface)
- Added variant selection checkboxes with Select All / Deselect All
- Added Custom Variant Builder: name field, 6 stem checkboxes, add/remove list
- Added vocals volume % control
- Progress bar now tracks total expected outputs (inputs x variants)
- Window auto-sizes to screen with scrollable content area
- Replaced all Unicode emoji with ASCII for Windows compatibility

### `gui/launch_gui.py` (GUI launcher)
- Replaced Unicode emoji with ASCII for Windows compatibility
- Translated French messages to English

### `README.md`
- Documented multi-variant feature with variant table
- Documented custom variant CLI usage with examples
- Added GUI section with launch instructions and feature list
- Updated CLI options documentation
- Added Wwise v2013 version requirement note
- Added CUDA PyTorch installation step

## Test plan

- [x] Process a single PSARC with default settings (should produce `no_guitar` variant only)
- [x] Process with `--variants all` (should produce 7 output files per input)
- [x] Process with `--variants no_vocals drums_only` (should produce 2 specific variants)
- [x] Process with `--custom "my_mix:drums,vocals"` (should produce custom variant output)
- [x] Mix built-in and custom: `--variants no_guitar --custom "keys:piano,other"`
- [x] Verify all variant outputs load in Rocksmith 2014 without collisions
- [x] Verify `--reduce-vocals 50` lowers vocal volume in applicable variants
- [x] Launch GUI and verify variant checkboxes, custom builder, progress bar, and processing work
- [x] Test on Windows with cp1252 console (no Unicode crashes)
